### PR TITLE
Suppress dead code warning, as dead code appears to be intentional.

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -14,6 +14,7 @@ use types::MutPointer;
 use std::collections::HashSet;
 use std::ffi::CString;
 use std::fs::File;
+use std::ops::Drop;
 use std::os::unix::prelude::*;
 use std::ptr;
 
@@ -151,5 +152,13 @@ impl BPF {
         let tracepoint = Tracepoint::attach_tracepoint(subsys, name, file)?;
         self.tracepoints.insert(tracepoint);
         Ok(())
+    }
+}
+
+impl Drop for BPF {
+    fn drop(&mut self) {
+        unsafe {
+            bpf_module_destroy(self.p);
+        };
     }
 }

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -45,6 +45,7 @@ impl Drop for PerfReader {
     }
 }
 
+#[allow(dead_code)]
 pub struct PerfMap {
     // table and callbacks are just in here to make sure the data stays owned/alive
     // TODO: improve this API


### PR DESCRIPTION
When doing a fresh compile, `rustc` complains that `table` and
`callbacks` are unused in `PerfMap`. There is a comment in `struct
PerfMap` that explains their presence, so it seems best to eliminate the
noise with a `#[allow(dead_code)]`.