### PR TITLE
Point to README examples in rust-bpf org repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ thing about these examples is that the Rust version isn't really more verbose th
 version. In some ways the Rust code is more legible because it's much more natural to work with C
 data structure in Rust than it is in Python.
 
-* [examples/strlen.rs](https://github.com/jvns/rust-bcc/blob/master/examples/strlen.rs) uses a BPF hashmap to count frequencies of every string that `strlen` is run on. Port of [strlen_count.py](https://github.com/iovisor/bcc/blob/master/examples/tracing/strlen_count.py) to Rust.
-* [examples/opensnoop.rs](https://github.com/jvns/rust-bcc/blob/master/examples/opensnoop.rs) uses perf events to track every time a file is opened on the system. Port of [opensnoop.py](https://github.com/iovisor/bcc/blob/master/examples/tracing/opensnoop.py) to Rust.
-* [examples/softirq.rs](https://github.com/jvns/rust-bcc/blob/master/examples/softirqs.rs) uses
+* [examples/strlen.rs](https://github.com/rust-bpf/rust-bcc/blob/master/examples/strlen.rs) uses a BPF hashmap to count frequencies of every string that `strlen` is run on. Port of [strlen_count.py](https://github.com/iovisor/bcc/blob/master/examples/tracing/strlen_count.py) to Rust.
+* [examples/opensnoop.rs](https://github.com/rust-bpf/rust-bcc/blob/master/examples/opensnoop.rs) uses perf events to track every time a file is opened on the system. Port of [opensnoop.py](https://github.com/iovisor/bcc/blob/master/examples/tracing/opensnoop.py) to Rust.
+* [examples/softirq.rs](https://github.com/rust-bpf/rust-bcc/blob/master/examples/softirqs.rs) uses
   kernel tracepoints to report time spent in softirq handlers. Port of [softirqs.py](https://github.com/iovisor/bcc/blob/master/tools/softirqs.py) to Rust.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! * Mimic the Python BCC bindings <https://github.com/iovisor/bcc>
 //!
 //! # Examples
-//! * see <https://github.com/jvns/rust-bcc/examples>
+//! * see <https://github.com/rust-bpf/rust-bcc/tree/master/examples>
 
 pub mod core;
 mod cpuonline;


### PR DESCRIPTION
Previously they were pointing to Julia Evans' (jvns) rust-bcc repo where this
code was originally hosted. Now that it has moved the related links have also
been altered.