### PR TITLE
merge cargo-release 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcc"
-version = "0.0.7-alpha.0"
+version = "0.0.7"
 authors = ["Julia Evans <julia@jvns.ca>", "Brian Martin <brayniac@gmail.com>"]
 description = "Idiomatic Rust bindings for BPF Compiler Collection (BCC)"
 keywords = ["bpf", "bindings", "bcc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcc"
-version = "0.0.7"
+version = "0.0.8-alpha.0"
 authors = ["Julia Evans <julia@jvns.ca>", "Brian Martin <brayniac@gmail.com>"]
 description = "Idiomatic Rust bindings for BPF Compiler Collection (BCC)"
 keywords = ["bpf", "bindings", "bcc"]


### PR DESCRIPTION
Ran cargo-release to push 0.0.7 to crates.io - but did it from my fork by accident. This diff lands the changes from the release process.