### PR TITLE
Bump version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcc"
-version = "0.0.8-alpha.0"
+version = "0.0.9-alpha.0"
 authors = ["Julia Evans <julia@jvns.ca>", "Brian Martin <brayniac@gmail.com>"]
 description = "Idiomatic Rust bindings for BPF Compiler Collection (BCC)"
 keywords = ["bpf", "bindings", "bcc"]


### PR DESCRIPTION
Incrementing the version number to get it back in-sync with crates.io