### PR TITLE
adds signal handler to examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,15 @@ homepage = "https://github.com/rust-bpf/rust-bcc"
 edition = '2018'
 
 [dependencies]
-libc = "0.2.55"
 bcc-sys = "0.9.2"
-failure = "0.1.5"
 byteorder = "1.3.1"
+failure = "0.1.5"
+libc = "0.2.55"
 
 [dev-dependencies]
-lazy_static = "1.3.0"
 clap = "2.33.0"
+ctrlc = "3.1.3"
+lazy_static = "1.3.0"
 
 [features]
 static = ["bcc-sys/static"]


### PR DESCRIPTION
Adds signal handlers for SIGINT and SIGTEM to the examples so that
the `Drop` implementations are invoked following ctrl-c.