### PR TITLE
add runqlat example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
   - cargo build --release --examples
   - ls /lib/modules/*/build
   - sudo target/release/examples/softirqs --interval 1 --windows 5
+  - sudo target/release/examples/runqlat --interval 1 --windows 5
 matrix:
   allow_failures:
     - rust: nightly
@@ -117,6 +118,7 @@ matrix:
         - cargo build --release --examples --features $BCC
         - ls /lib/modules/*/build
         - sudo target/release/examples/softirqs --interval 1 --windows 5
+        - sudo target/release/examples/runqlat --interval 1 --windows 5
     - os: linux
       dist: xenial
       rust: stable
@@ -146,6 +148,7 @@ matrix:
         - cargo build --release --examples --features $BCC
         - ls /lib/modules/*/build
         - sudo target/release/examples/softirqs --interval 1 --windows 5
+        - sudo target/release/examples/runqlat --interval 1 --windows 5
     - os: linux
       dist: xenial
       rust: stable
@@ -175,6 +178,7 @@ matrix:
         - cargo build --release --examples --features $BCC
         - ls /lib/modules/*/build
         - sudo target/release/examples/softirqs --interval 1 --windows 5
+        - sudo target/release/examples/runqlat --interval 1 --windows 5
     - os: linux
       dist: xenial
       rust: stable
@@ -204,6 +208,7 @@ matrix:
         - cargo build --release --examples --features $BCC
         - ls /lib/modules/*/build
         - sudo target/release/examples/softirqs --interval 1 --windows 5
+        - sudo target/release/examples/runqlat --interval 1 --windows 5
     - os: linux
       dist: xenial
       rust: stable
@@ -233,6 +238,7 @@ matrix:
         - cargo build --release --examples --features $BCC
         - ls /lib/modules/*/build
         - sudo target/release/examples/softirqs --interval 1 --windows 5
+        - sudo target/release/examples/runqlat --interval 1 --windows 5
     - os: linux
       dist: xenial
       rust: stable
@@ -262,6 +268,7 @@ matrix:
         - cargo build --release --examples --features $BCC
         - ls /lib/modules/*/build
         - sudo target/release/examples/softirqs --interval 1 --windows 5
+        - sudo target/release/examples/runqlat --interval 1 --windows 5
 cache:
   directories:
     - $HOME/.cargo

--- a/examples/runqlat.c
+++ b/examples/runqlat.c
@@ -1,0 +1,68 @@
+#include <uapi/linux/ptrace.h>
+#include <linux/sched.h>
+#include <linux/nsproxy.h>
+#include <linux/pid_namespace.h>
+
+typedef struct pid_key {
+    u64 id;    // work around
+    u64 slot;
+} pid_key_t;
+
+typedef struct pidns_key {
+    u64 id;    // work around
+    u64 slot;
+} pidns_key_t;
+
+BPF_HASH(start, u32);
+BPF_HISTOGRAM(dist);
+struct rq;
+
+// record enqueue timestamp
+static int trace_enqueue(u32 tgid, u32 pid)
+{
+    if (pid == 0)
+        return 0;
+    u64 ts = bpf_ktime_get_ns();
+    start.update(&pid, &ts);
+    return 0;
+}
+
+int trace_wake_up_new_task(struct pt_regs *ctx, struct task_struct *p)
+{
+    return trace_enqueue(p->tgid, p->pid);
+}
+int trace_ttwu_do_wakeup(struct pt_regs *ctx, struct rq *rq, struct task_struct *p,
+    int wake_flags)
+{
+    return trace_enqueue(p->tgid, p->pid);
+}
+// calculate latency
+int trace_run(struct pt_regs *ctx, struct task_struct *prev)
+{
+    u32 pid, tgid;
+    // ivcsw: treat like an enqueue event and store timestamp
+    if (prev->state == TASK_RUNNING) {
+        tgid = prev->tgid;
+        pid = prev->pid;
+        if (pid != 0) {
+            u64 ts = bpf_ktime_get_ns();
+            start.update(&pid, &ts);
+        }
+    }
+    tgid = bpf_get_current_pid_tgid() >> 32;
+    pid = bpf_get_current_pid_tgid();
+    if (pid == 0)
+        return 0;
+    u64 *tsp, delta;
+    // fetch timestamp and calculate delta
+    tsp = start.lookup(&pid);
+    if (tsp == 0) {
+        return 0;   // missed enqueue
+    }
+    delta = bpf_ktime_get_ns() - *tsp;
+    delta /= 1000; // microseconds
+    // store as histogram
+    dist.increment(bpf_log2l(delta));
+    start.delete(&pid);
+    return 0;
+}

--- a/examples/runqlat.rs
+++ b/examples/runqlat.rs
@@ -1,0 +1,103 @@
+use bcc::core::BPF;
+use clap::{App, Arg};
+use failure::Error;
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::{mem, thread, time};
+
+// A simple tool for reporting runqueue latency
+//
+// Based on: https://github.com/iovisor/bcc/blob/master/tools/runqlat.py
+
+fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+    let matches = App::new("runqlat")
+        .about("Reports distribution of scheduler latency")
+        .arg(
+            Arg::with_name("interval")
+                .long("interval")
+                .value_name("Seconds")
+                .help("Integration window duration and period for stats output")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("windows")
+                .long("windows")
+                .value_name("Count")
+                .help("The number of intervals before exit")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let interval: usize = matches
+        .value_of("interval")
+        .unwrap_or("1")
+        .parse()
+        .expect("Invalid argument for interval");
+    let windows: Option<usize> = matches
+        .value_of("windows")
+        .map(|v| v.parse().expect("Invalid argument for windows"));
+
+    let code = include_str!("runqlat.c");
+    // compile the above BPF code!
+    let mut bpf = BPF::new(code)?;
+
+    // load + attach kprobes!
+    let trace_run = bpf.load_kprobe("trace_run")?;
+    let trace_ttwu_do_wakeup = bpf.load_kprobe("trace_ttwu_do_wakeup")?;
+    let trace_wake_up_new_task = bpf.load_kprobe("trace_wake_up_new_task")?;
+
+    bpf.attach_kprobe("finish_task_switch", trace_run)?;
+    bpf.attach_kprobe("wake_up_new_task", trace_wake_up_new_task)?;
+    bpf.attach_kprobe("ttwu_do_wakeup", trace_ttwu_do_wakeup)?;
+
+    let table = bpf.table("dist");
+    let mut window = 0;
+
+    while runnable.load(Ordering::SeqCst) {
+        thread::sleep(time::Duration::new(interval as u64, 0));
+        println!("======");
+        let mut overflow = 0;
+        for (power, entry) in table.iter().enumerate() {
+            let value = entry.value;
+
+            let mut v = [0_u8; 8];
+            for i in 0..8 {
+                v[i] = *value.get(i).unwrap_or(&0);
+            }
+            let count: u64 = unsafe { mem::transmute(v) };
+            let value = 2_u64.pow(power as u32);
+            if value < 1_000_000 {
+                println!("{} uS: {}", 2_u64.pow(power as u32), count);
+            } else {
+                overflow += count;
+            }
+        }
+        println!("> 1 S: {}", overflow);
+        if let Some(windows) = windows {
+            window += 1;
+            if window >= windows {
+                return Ok(());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn main() {
+    let runnable = Arc::new(AtomicBool::new(true));
+    let r = runnable.clone();
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    })
+    .expect("Failed to set handler for SIGINT / SIGTERM");
+
+    match do_main(runnable) {
+        Err(x) => {
+            eprintln!("Error: {}", x);
+            eprintln!("{}", x.backtrace());
+            std::process::exit(1);
+        }
+        _ => {}
+    }
+}


### PR DESCRIPTION
Adds an example that is based on runqlat.py which displays the
distribution of runqueue latency. This example is structured
like the softirqs example in that it is appropriate for use in
ci, but exercises the use of kprobes instead of tracepoints.