### PR TITLE
example opensnoop doesn't run and I've fixed it

### DIFF
--- a/examples/opensnoop.rs
+++ b/examples/opensnoop.rs
@@ -55,17 +55,14 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
     Ok(())
 }
 
-fn perf_data_callback() -> Box<FnMut(&[u8]) + Send> {
-    Box::new(|x| {
-        // This callback
-        let data = parse_struct(x);
-        println!(
-            "{:-7} {:-16} {}",
-            data.id >> 32,
-            get_string(&data.comm),
-            get_string(&data.fname)
-        );
-    })
+fn perf_data_callback(x: &[u8]) {
+    let data = parse_struct(x);
+    println!(
+        "{:-7} {:-16} {}",
+        data.id >> 32,
+        get_string(&data.comm),
+        get_string(&data.fname)
+    );
 }
 
 fn parse_struct(x: &[u8]) -> data_t {

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -69,7 +69,7 @@ where
     let mut cur = Cursor::new(leaf);
 
     let cpus = cpuonline::get()?;
-    for cpu in cpus.iter() {
+    for (i, cpu) in cpus.iter().enumerate() {
         unsafe {
             let (mut reader, callback) = open_perf_buffer(*cpu, cb())?;
             let perf_fd = reader.fd() as u32;
@@ -80,13 +80,15 @@ where
             table
                 .set(&mut key, &mut cur.get_mut())
                 .context("Unable to initialize perf map")?;
-            let r = bpf_get_next_key(
-                fd,
-                key.as_mut_ptr() as MutPointer,
-                key.as_mut_ptr() as MutPointer,
-            );
-            if r != 0 {
-                return Err(format_err!("todo: oh no"));
+            if i < cpus.len() - 1 {
+              let r = bpf_get_next_key(
+                  fd,
+                  key.as_mut_ptr() as MutPointer,
+                  key.as_mut_ptr() as MutPointer,
+              );
+              if r != 0 {
+                  return Err(format_err!("todo: oh no"));
+              }
             }
             cur.set_position(0);
         }


### PR DESCRIPTION
First try with the exmple program, I get `todo: oh no`. It seems that `bpf_get_next_key` for the last CPU will fail so I [fixed it](https://github.com/lilydjwg/rust-bcc/commit/5af97893b0c4d7e9074c66eabf6b4184a81c4385).

Second try, I get SIGSEGV at the callback. The pointer passed to `bpf_open_perf_buffer` refers to an object on stack.

https://github.com/rust-bpf/rust-bcc/blob/f06554ada710fd18ce07f3042cb60adc179cd648/src/perf.rs#L117-L122

I didn't figure out what `PerfCallback` does so I [replaced it altogether with plain function pointers](https://github.com/lilydjwg/rust-bcc/commit/731318545bef6d2a0e9803f497c04bd5e935b3c6) and it seems to work.

I didn't update other examples for now. If the changes seem good, I can update others.