### PR TITLE
impl get_kprobe_functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bcc-sys = "0.10.0"
 byteorder = "1.3.1"
 failure = "0.1.5"
 libc = "0.2.55"
-regex = "1"
+regex = "1.3.1"
 
 [dev-dependencies]
 clap = "2.33.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bcc-sys = "0.10.0"
 byteorder = "1.3.1"
 failure = "0.1.5"
 libc = "0.2.55"
+regex = "1"
 
 [dev-dependencies]
 clap = "2.33.0"

--- a/src/core/kprobe/v0_4_0.rs
+++ b/src/core/kprobe/v0_4_0.rs
@@ -6,9 +6,11 @@ use failure::*;
 use crate::core::make_alphanumeric;
 use crate::types::MutPointer;
 
+use regex::Regex;
 use std::ffi::CString;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
+use std::io::{BufRead, BufReader};
 use std::os::unix::prelude::*;
 use std::ptr;
 
@@ -60,6 +62,67 @@ impl Kprobe {
         let name = format!("r_{}", &make_alphanumeric(function));
         Kprobe::new(&name, BPF_PROBE_RETURN, function, code)
             .map_err(|_| format_err!("Failed to attach Kretprobe: {}", name))
+    }
+
+    pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>, Error> {
+        let mut fns: Vec<String> = vec![];
+
+        let mut in_init_section = 0;
+        let mut in_irq_section = 0;
+        let re = Regex::new(r"^.*\.cold\.\d+$").unwrap();
+        let avali = BufReader::new(File::open("/proc/kallsyms").unwrap());
+        for line in avali.lines() {
+            let line = line.unwrap();
+            let cols: Vec<&str> = line.split_whitespace().collect();
+            let (t, fname) = (cols[1].to_string().to_lowercase(), cols[2]);
+            // Skip all functions defined between __init_begin and
+            // __init_end
+            if in_init_section == 0 {
+                if fname == "__init_begin" {
+                    in_init_section = 1;
+                    continue;
+                }
+            } else if in_init_section == 1 {
+                if fname == "__init_end" {
+                    in_init_section = 2;
+                }
+                continue;
+            }
+            // Skip all functions defined between __irqentry_text_start and
+            // __irqentry_text_end
+            if in_irq_section == 0 {
+                if fname == "__irqentry_text_start" {
+                    in_irq_section = 1;
+                    continue;
+                }
+            } else if in_irq_section == 1 {
+                if fname == "__irqentry_text_end" {
+                    in_irq_section = 2;
+                }
+                continue;
+            }
+            // All functions defined as NOKPROBE_SYMBOL() start with the
+            // prefix _kbl_addr_*, blacklisting them by looking at the name
+            // allows to catch also those symbols that are defined in kernel
+            // modules.
+            if fname.starts_with("_kbl_addr_") {
+                continue;
+            }
+            // Explicitly blacklist perf-related functions, they are all
+            // non-attachable.
+            else if fname.starts_with("__perf") || fname.starts_with("perf_") {
+                continue;
+            }
+            // Exclude all gcc 8's extra .cold functions
+            else if re.is_match(fname) {
+                continue;
+            }
+            if (t == "t" || t == "w") && fname.contains(event_re) {
+                fns.push(fname.to_owned());
+            }
+        }
+
+        Ok(fns)
     }
 }
 

--- a/src/core/kprobe/v0_6_0.rs
+++ b/src/core/kprobe/v0_6_0.rs
@@ -6,6 +6,7 @@ use failure::*;
 use crate::core::make_alphanumeric;
 
 use regex::Regex;
+
 use std::ffi::CString;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
@@ -60,8 +61,14 @@ impl Kprobe {
     pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>, Error> {
         let mut fns: Vec<String> = vec![];
 
-        let mut in_init_section = 0;
-        let mut in_irq_section = 0;
+        enum Section {
+            Unmatched,
+            Begin,
+            End,
+        }
+
+        let mut in_init_section = Section::Unmatched;
+        let mut in_irq_section = Section::Unmatched;
         let re = Regex::new(r"^.*\.cold\.\d+$").unwrap();
         let avali = BufReader::new(File::open("/proc/kallsyms").unwrap());
         for line in avali.lines() {
@@ -70,29 +77,37 @@ impl Kprobe {
             let (t, fname) = (cols[1].to_string().to_lowercase(), cols[2]);
             // Skip all functions defined between __init_begin and
             // __init_end
-            if in_init_section == 0 {
-                if fname == "__init_begin" {
-                    in_init_section = 1;
+            match in_init_section {
+                Section::Unmatched => {
+                    if fname == "__init_begin" {
+                        in_init_section = Section::Begin;
+                        continue;
+                    }
+                }
+                Section::Begin => {
+                    if fname == "__init_end" {
+                        in_init_section = Section::End;
+                    }
                     continue;
                 }
-            } else if in_init_section == 1 {
-                if fname == "__init_end" {
-                    in_init_section = 2;
-                }
-                continue;
+                Section::End => (),
             }
             // Skip all functions defined between __irqentry_text_start and
             // __irqentry_text_end
-            if in_irq_section == 0 {
-                if fname == "__irqentry_text_start" {
-                    in_irq_section = 1;
+            match in_irq_section {
+                Section::Unmatched => {
+                    if fname == "__irqentry_text_start" {
+                        in_irq_section = Section::Begin;
+                        continue;
+                    }
+                }
+                Section::Begin => {
+                    if fname == "__irqentry_text_end" {
+                        in_irq_section = Section::End;
+                    }
                     continue;
                 }
-            } else if in_irq_section == 1 {
-                if fname == "__irqentry_text_end" {
-                    in_irq_section = 2;
-                }
-                continue;
+                Section::End => (),
             }
             // All functions defined as NOKPROBE_SYMBOL() start with the
             // prefix _kbl_addr_*, blacklisting them by looking at the name

--- a/src/core/kprobe/v0_9_0.rs
+++ b/src/core/kprobe/v0_9_0.rs
@@ -6,6 +6,7 @@ use failure::*;
 use crate::core::make_alphanumeric;
 
 use regex::Regex;
+
 use std::ffi::CString;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
@@ -61,8 +62,14 @@ impl Kprobe {
     pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>, Error> {
         let mut fns: Vec<String> = vec![];
 
-        let mut in_init_section = 0;
-        let mut in_irq_section = 0;
+        enum Section {
+            Unmatched,
+            Begin,
+            End,
+        }
+
+        let mut in_init_section = Section::Unmatched;
+        let mut in_irq_section = Section::Unmatched;
         let re = Regex::new(r"^.*\.cold\.\d+$").unwrap();
         let avali = BufReader::new(File::open("/proc/kallsyms").unwrap());
         for line in avali.lines() {
@@ -71,29 +78,37 @@ impl Kprobe {
             let (t, fname) = (cols[1].to_string().to_lowercase(), cols[2]);
             // Skip all functions defined between __init_begin and
             // __init_end
-            if in_init_section == 0 {
-                if fname == "__init_begin" {
-                    in_init_section = 1;
+            match in_init_section {
+                Section::Unmatched => {
+                    if fname == "__init_begin" {
+                        in_init_section = Section::Begin;
+                        continue;
+                    }
+                }
+                Section::Begin => {
+                    if fname == "__init_end" {
+                        in_init_section = Section::End;
+                    }
                     continue;
                 }
-            } else if in_init_section == 1 {
-                if fname == "__init_end" {
-                    in_init_section = 2;
-                }
-                continue;
+                Section::End => (),
             }
             // Skip all functions defined between __irqentry_text_start and
             // __irqentry_text_end
-            if in_irq_section == 0 {
-                if fname == "__irqentry_text_start" {
-                    in_irq_section = 1;
+            match in_irq_section {
+                Section::Unmatched => {
+                    if fname == "__irqentry_text_start" {
+                        in_irq_section = Section::Begin;
+                        continue;
+                    }
+                }
+                Section::Begin => {
+                    if fname == "__irqentry_text_end" {
+                        in_irq_section = Section::End;
+                    }
                     continue;
                 }
-            } else if in_irq_section == 1 {
-                if fname == "__irqentry_text_end" {
-                    in_irq_section = 2;
-                }
-                continue;
+                Section::End => (),
             }
             // All functions defined as NOKPROBE_SYMBOL() start with the
             // prefix _kbl_addr_*, blacklisting them by looking at the name

--- a/src/core/kprobe/v0_9_0.rs
+++ b/src/core/kprobe/v0_9_0.rs
@@ -5,9 +5,11 @@ use failure::*;
 
 use crate::core::make_alphanumeric;
 
+use regex::Regex;
 use std::ffi::CString;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
+use std::io::{BufRead, BufReader};
 use std::os::unix::prelude::*;
 
 #[derive(Debug)]
@@ -54,6 +56,67 @@ impl Kprobe {
         let name = format!("r_{}", &make_alphanumeric(function));
         Kprobe::new(&name, BPF_PROBE_RETURN, function, code)
             .map_err(|_| format_err!("Failed to attach Kretprobe: {}", name))
+    }
+
+    pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>, Error> {
+        let mut fns: Vec<String> = vec![];
+
+        let mut in_init_section = 0;
+        let mut in_irq_section = 0;
+        let re = Regex::new(r"^.*\.cold\.\d+$").unwrap();
+        let avali = BufReader::new(File::open("/proc/kallsyms").unwrap());
+        for line in avali.lines() {
+            let line = line.unwrap();
+            let cols: Vec<&str> = line.split_whitespace().collect();
+            let (t, fname) = (cols[1].to_string().to_lowercase(), cols[2]);
+            // Skip all functions defined between __init_begin and
+            // __init_end
+            if in_init_section == 0 {
+                if fname == "__init_begin" {
+                    in_init_section = 1;
+                    continue;
+                }
+            } else if in_init_section == 1 {
+                if fname == "__init_end" {
+                    in_init_section = 2;
+                }
+                continue;
+            }
+            // Skip all functions defined between __irqentry_text_start and
+            // __irqentry_text_end
+            if in_irq_section == 0 {
+                if fname == "__irqentry_text_start" {
+                    in_irq_section = 1;
+                    continue;
+                }
+            } else if in_irq_section == 1 {
+                if fname == "__irqentry_text_end" {
+                    in_irq_section = 2;
+                }
+                continue;
+            }
+            // All functions defined as NOKPROBE_SYMBOL() start with the
+            // prefix _kbl_addr_*, blacklisting them by looking at the name
+            // allows to catch also those symbols that are defined in kernel
+            // modules.
+            if fname.starts_with("_kbl_addr_") {
+                continue;
+            }
+            // Explicitly blacklist perf-related functions, they are all
+            // non-attachable.
+            else if fname.starts_with("__perf") || fname.starts_with("perf_") {
+                continue;
+            }
+            // Exclude all gcc 8's extra .cold functions
+            else if re.is_match(fname) {
+                continue;
+            }
+            if (t == "t" || t == "w") && fname.contains(event_re) {
+                fns.push(fname.to_owned());
+            }
+        }
+
+        Ok(fns)
     }
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -271,6 +271,10 @@ impl BPF {
         Ok(())
     }
 
+    pub fn get_kprobe_functions(&mut self, event_re: &str) -> Result<Vec<String>, Error> {
+        Kprobe::get_kprobe_functions(event_re)
+    }
+
     pub fn attach_uprobe(
         &mut self,
         binary_path: &str,


### PR DESCRIPTION
I think we can implement `get_kprobe_functions` which bcc's python API has implemented. I tested this with https://github.com/ethercflow/bpftools/blob/master/src/bin/biosnoop.rs#L51, it seems fine.  BTW, after #51 is fixed. I want to make `biosnoop` as example PR too. Thank you. @brayniac 