### PR TITLE
Use 'dyn' since trait objects without an explicit 'dyn' are deprecated

### DIFF
--- a/examples/opensnoop.rs
+++ b/examples/opensnoop.rs
@@ -77,7 +77,7 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
     Ok(())
 }
 
-fn perf_data_callback() -> Box<FnMut(&[u8]) + Send> {
+fn perf_data_callback() -> Box<dyn FnMut(&[u8]) + Send> {
     Box::new(|x| {
         // This callback
         let data = parse_struct(x);

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -10,7 +10,7 @@ use crate::table::Table;
 use crate::types::*;
 
 struct PerfCallback {
-    raw_cb: Box<FnMut(&[u8]) + Send>,
+    raw_cb: Box<dyn FnMut(&[u8]) + Send>,
 }
 
 const BPF_PERF_READER_PAGE_CNT: i32 = 64;
@@ -52,7 +52,7 @@ pub struct PerfMap {
 
 pub fn init_perf_map<F>(mut table: Table, cb: F) -> Result<PerfMap, Error>
 where
-    F: Fn() -> Box<FnMut(&[u8]) + Send>,
+    F: Fn() -> Box<dyn FnMut(&[u8]) + Send>,
 {
     let key_size = table.key_size();
     let leaf_size = table.leaf_size();
@@ -102,7 +102,7 @@ impl PerfMap {
 
 fn open_perf_buffer(
     cpu: usize,
-    raw_cb: Box<FnMut(&[u8]) + Send>,
+    raw_cb: Box<dyn FnMut(&[u8]) + Send>,
 ) -> Result<(PerfReader, Box<PerfCallback>), Error> {
     let mut callback = Box::new(PerfCallback { raw_cb });
     let reader = unsafe {


### PR DESCRIPTION
briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this
  change?)
-> I found that `trait objects without an explicit `dyn` are deprecated` - https://travis-ci.org/rust-bpf/rust-bcc/jobs/582822868, and I followed the suggestion given by the compile to fix this.

* what changes does this pull request make?
-> Use 'dyn' since trait objects without an explicit 'dyn' are deprecated
* are there any non-obvious implications of these changes? (does it break compatibility with previous
  versions, etc)
-> I will have to check the travis build for this PR.
