### PR TITLE
fix a segfault caused by passing a non-null buffer to bpf_prog_load

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -33,6 +33,14 @@ fn make_alphanumeric(s: &str) -> String {
     )
 }
 
+fn null_or_mut_ptr<T>(s: &mut Vec<u8>) -> *mut T {
+    if s.capacity() == 0 {
+        ptr::null_mut()
+    } else {
+        s.as_mut_ptr() as *mut T
+    }
+}
+
 impl BPF {
     /// `code` is a string containing C code. See https://github.com/iovisor/bcc for examples
     #[cfg(any(
@@ -140,7 +148,7 @@ impl BPF {
                 size,
                 license,
                 version,
-                log_buf.as_mut_ptr() as *mut i8,
+                null_or_mut_ptr(&mut log_buf),
                 log_buf.capacity() as u32,
             );
             if fd < 0 {
@@ -237,7 +245,7 @@ impl BPF {
                 license,
                 version,
                 log_level,
-                log_buf.as_mut_ptr() as *mut i8,
+                null_or_mut_ptr(&mut log_buf),
                 log_buf.capacity() as u32,
             );
             if fd < 0 {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -193,7 +193,7 @@ impl BPF {
                 license,
                 version,
                 log_level,
-                log_buf.as_mut_ptr() as *mut i8,
+                null_or_mut_ptr(&mut log_buf),
                 log_buf.capacity() as u32,
             );
             if fd < 0 {

--- a/tests/error.c
+++ b/tests/error.c
@@ -1,0 +1,7 @@
+int trace_return(struct pt_regs *ctx)
+{
+  // Infinite loop, this should fail the verifier.
+  for (;;) {}
+  return 0;
+}
+

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -9,13 +9,12 @@ mod tests {
 
     use bcc::core::BPF;
 
-    use std::ptr;
     #[test]
     fn error_handling() {
         let code = include_str!("error.c");
         // compile the above BPF code!
         let mut module = BPF::new(code).unwrap();
-        match (module.load_kprobe("trace_return")) {
+        match module.load_kprobe("trace_return") {
             Ok(_) => {
                 eprintln!("expected error during program load");
                 std::process::exit(1);

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,0 +1,26 @@
+/*
+ * Regression test for a segfault occuring in bcc when bpf_load_prog fails and attempts
+ * to populate a non-null buffer with the error message.
+ */
+#[cfg(test)]
+mod tests {
+
+    extern crate bcc;
+
+    use bcc::core::BPF;
+
+    use std::ptr;
+    #[test]
+    fn error_handling() {
+        let code = include_str!("error.c");
+        // compile the above BPF code!
+        let mut module = BPF::new(code).unwrap();
+        match (module.load_kprobe("trace_return")) {
+            Ok(_) => {
+                eprintln!("expected error during program load");
+                std::process::exit(1);
+            }
+            Err(_) => {}
+        };
+    }
+}


### PR DESCRIPTION
During error handling bcc will attempt to write the message to the
provided buffer. It checks for a provided buffer either by checking the
log_buf_size parameter or by checking log_buf to see if it's non-null.

Because of the inconsistent checks on bcc's side and the specific
parameters that rust-bcc passes, this is only a problem when the call to
bpf_prog_load returns certain errors.

The flow that causes the segfault looks like this: rust-bcc sets log_level=0,log_size=0
as the initial parameters. bcc will issue the syscall, but upon failure will reissue
the bcc_prog_load_xattr with log_level set to 1. At this point, the same error will be
produced and outputted to a new, temporary buffer (since the provided
log_size is 0). Following this, it will attempt to log to the user provided
buffer as log_level is now > 0, checking to see if the provided buffer
is non-null. As rust-bcc provided a non-null ptr, bcc attempts to write
to a zero buffer which causes a SIGSEGV.

Relevant links:
Checks for log_buf_size:
https://github.com/iovisor/bcc/blob/d147588ebe35b7cd2b4d253a7da18bef253ea78d/src/cc/libbpf.c#L519

Checks for log_buf:
https://github.com/iovisor/bcc/blob/d147588ebe35b7cd2b4d253a7da18bef253ea78d/src/cc/libbpf.c#L641
