### PR TITLE
Support poll multi perf_buffer at once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
   - sudo target/release/examples/runqlat --interval 1 --windows 5
   - sudo target/release/examples/opensnoop --duration 5
   - sudo target/release/examples/biosnoop --duration 5
+  - sudo target/release/examples/tcpretrans --duration 5
 matrix:
   allow_failures:
     - rust: nightly
@@ -117,6 +118,7 @@ matrix:
         - sudo target/release/examples/runqlat --interval 1 --windows 5
         - sudo target/release/examples/opensnoop --duration 5
         - sudo target/release/examples/biosnoop --duration 5
+        - sudo target/release/examples/tcpretrans --duration 5
     - os: linux
       dist: bionic
       rust: stable
@@ -146,6 +148,7 @@ matrix:
         - sudo target/release/examples/runqlat --interval 1 --windows 5
         - sudo target/release/examples/opensnoop --duration 5
         - sudo target/release/examples/biosnoop --duration 5
+        - sudo target/release/examples/tcpretrans --duration 5
     - os: linux
       dist: bionic
       rust: stable
@@ -175,6 +178,7 @@ matrix:
         - sudo target/release/examples/runqlat --interval 1 --windows 5
         - sudo target/release/examples/opensnoop --duration 5
         - sudo target/release/examples/biosnoop --duration 5
+        - sudo target/release/examples/tcpretrans --duration 5
     - os: linux
       dist: bionic
       rust: stable
@@ -204,6 +208,7 @@ matrix:
         - sudo target/release/examples/runqlat --interval 1 --windows 5
         - sudo target/release/examples/opensnoop --duration 5
         - sudo target/release/examples/biosnoop --duration 5
+        - sudo target/release/examples/tcpretrans --duration 5
     - os: linux
       dist: bionic
       rust: stable
@@ -233,6 +238,7 @@ matrix:
         - sudo target/release/examples/runqlat --interval 1 --windows 5
         - sudo target/release/examples/opensnoop --duration 5
         - sudo target/release/examples/biosnoop --duration 5
+        - sudo target/release/examples/tcpretrans --duration 5
     - os: linux
       dist: bionic
       rust: stable
@@ -262,3 +268,4 @@ matrix:
         - sudo target/release/examples/runqlat --interval 1 --windows 5
         - sudo target/release/examples/opensnoop --duration 5
         - sudo target/release/examples/biosnoop --duration 5
+        - sudo target/release/examples/tcpretrans --duration 5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ regex = "1.3.1"
 clap = "2.33.0"
 ctrlc = "3.1.3"
 lazy_static = "1.3.0"
+chrono = "0.4"
 
 [features]
 static = ["bcc-sys/static"]

--- a/examples/tcpretrans.c
+++ b/examples/tcpretrans.c
@@ -1,0 +1,92 @@
+#include <uapi/linux/ptrace.h>
+#include <net/sock.h>
+#include <bcc/proto.h>
+
+// This code is taken from: https://github.com/iovisor/bcc/blob/master/tools/tcpretrans.py
+//
+// Copyright 2016 Netflix, Inc. 
+// Licensed under the Apache License, Version 2.0 (the "License")
+ 
+#define RETRANSMIT  1
+#define TLP         2
+
+// separate data structs for ipv4 and ipv6
+struct ipv4_data_t {
+    u32 pid;
+    u64 ip;
+    u32 saddr;
+    u32 daddr;
+    u16 lport;
+    u16 dport;
+    u64 state;
+    u64 type;
+};
+BPF_PERF_OUTPUT(ipv4_events);
+
+struct ipv6_data_t {
+    u32 pid;
+    u64 ip;
+    unsigned __int128 saddr;
+    unsigned __int128 daddr;
+    u16 lport;
+    u16 dport;
+    u64 state;
+    u64 type;
+};
+BPF_PERF_OUTPUT(ipv6_events);
+
+static int trace_event(struct pt_regs *ctx, struct sock *skp, int type)
+{
+    if (skp == NULL)
+        return 0;
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
+
+    // pull in details
+    u16 family = skp->__sk_common.skc_family;
+    u16 lport = skp->__sk_common.skc_num;
+    u16 dport = skp->__sk_common.skc_dport;
+    char state = skp->__sk_common.skc_state;
+
+    if (family == AF_INET) {
+        struct ipv4_data_t data4 = {};
+        data4.pid = pid;
+        data4.ip = 4;
+        data4.type = type;
+        data4.saddr = skp->__sk_common.skc_rcv_saddr;
+        data4.daddr = skp->__sk_common.skc_daddr;
+        // lport is host order
+        data4.lport = lport;
+        data4.dport = ntohs(dport);
+        data4.state = state; 
+        ipv4_events.perf_submit(ctx, &data4, sizeof(data4));
+    } else if (family == AF_INET6) {
+        struct ipv6_data_t data6 = {};
+        data6.pid = pid;
+        data6.ip = 6;
+        data6.type = type;
+        bpf_probe_read(&data6.saddr, sizeof(data6.saddr),
+                       skp->__sk_common.skc_v6_rcv_saddr.in6_u.u6_addr32);
+        bpf_probe_read(&data6.daddr, sizeof(data6.daddr),
+                       skp->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
+        // lport is host order
+        data6.lport = lport;
+        data6.dport = ntohs(dport);
+        data6.state = state;
+        ipv6_events.perf_submit(ctx, &data6, sizeof(data6));
+    }
+    // else drop
+
+    return 0;
+}
+
+int trace_retransmit(struct pt_regs *ctx, struct sock *sk)
+{
+    trace_event(ctx, sk, RETRANSMIT);
+    return 0;
+}
+
+int trace_tlp(struct pt_regs *ctx, struct sock *sk)
+{
+    trace_event(ctx, sk, TLP);
+    return 0;
+}

--- a/examples/tcpretrans.rs
+++ b/examples/tcpretrans.rs
@@ -1,0 +1,137 @@
+use bcc::core::BPF;
+extern crate chrono;
+use chrono::Utc;
+use clap::{App, Arg};
+use failure::Error;
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::net::Ipv4Addr;
+use std::net::Ipv6Addr;
+use std::ptr;
+use std::sync::Arc;
+
+// A simple tool for tracing tcp retransmits.
+//
+// Based on: https://github.com/iovisor/bcc/blob/master/tools/tcpretrans.py
+
+#[repr(C)]
+struct ipv4_data_t {
+    pid: u32,
+    ip: u64,
+    saddr: u32,
+    daddr: u32,
+    lport: u16,
+    dport: u16,
+    state: u64,
+    type_: u64,
+}
+
+#[repr(C)]
+struct ipv6_data_t {
+    pid: u32,
+    ip: u64,
+    saddr: u128,
+    daddr: u128,
+    lport: u16,
+    dport: u16,
+    state: u64,
+    type_: u64,
+}
+
+fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+    let matches = App::new("biosnoop")
+        .arg(
+            Arg::with_name("duration")
+                .long("duration")
+                .value_name("Seconds")
+                .help("The total duration to run this tool")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let duration: Option<std::time::Duration> = matches
+        .value_of("duration")
+        .map(|v| std::time::Duration::new(v.parse().expect("Invalid argument for duration"), 0));
+
+    let code = include_str!("tcpretrans.c");
+    // compile the above BPF code!
+    let mut bpf = BPF::new(&code)?;
+
+    let trace_retransmit = bpf.load_kprobe("trace_retransmit")?;
+    bpf.attach_kprobe("tcp_retransmit_skb", trace_retransmit)?;
+
+    let table = bpf.table("ipv4_events");
+    bpf.init_perf_map(table, print_ipv4_event)?;
+    let table = bpf.table("ipv6_events");
+    bpf.init_perf_map(table, print_ipv6_event)?;
+
+    println!(
+        "{:<-8} {:<-6} {:<-2} {:<-20} {:>-1} {:<-20} {:<-4}",
+        "TIME", "PID", "IP", "LADDR:LPORT", "T", "RADDR:RPORT", "STATE"
+    );
+    let start = std::time::Instant::now();
+    while runnable.load(Ordering::SeqCst) {
+        bpf.perf_map_poll(200);
+        if let Some(d) = duration {
+            if std::time::Instant::now() - start >= d {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_ipv4_event() -> Box<FnMut(&[u8]) + Send> {
+    Box::new(|x| {
+        let event = parse_ipv4_struct(x);
+        println!(
+            "{:<-8} {:<-6} {:<-2} {:<-20} {:->1}> {:<-20} {:>-4}",
+            Utc::now().format("%T"),
+            event.pid,
+            event.ip,
+            format!("{}:{}", Ipv4Addr::from(event.saddr), event.lport),
+            event.type_,
+            format!("{}:{}", Ipv4Addr::from(event.daddr), event.dport),
+            event.state,
+        );
+    })
+}
+
+fn print_ipv6_event() -> Box<FnMut(&[u8]) + Send> {
+    Box::new(|x| {
+        let event = parse_ipv6_struct(x);
+        println!(
+            "{:<-8} {:<-6} {:<-2}  {:<-20} {:->1}> {:<-20} {:>-4}",
+            Utc::now().format("%T"),
+            event.pid,
+            event.ip,
+            format!("{}:{}", Ipv6Addr::from(event.saddr), event.lport),
+            event.type_,
+            format!("{}:{}", Ipv6Addr::from(event.daddr), event.dport),
+            event.state,
+        );
+    })
+}
+
+fn parse_ipv4_struct(x: &[u8]) -> ipv4_data_t {
+    unsafe { ptr::read(x.as_ptr() as *const ipv4_data_t) }
+}
+
+fn parse_ipv6_struct(x: &[u8]) -> ipv6_data_t {
+    unsafe { ptr::read(x.as_ptr() as *const ipv6_data_t) }
+}
+
+fn main() {
+    let runnable = Arc::new(AtomicBool::new(true));
+    let r = runnable.clone();
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    })
+    .expect("Failed to set handler for SIGINT / SIGTERM");
+
+    if let Err(x) = do_main(runnable) {
+        eprintln!("Error: {}", x);
+        eprintln!("{}", x.backtrace());
+        std::process::exit(1);
+    }
+}

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -25,7 +25,8 @@ unsafe extern "C" fn raw_callback(pc: MutPointer, ptr: MutPointer, size: i32) {
 // need this to be represented in memory as just a pointer!!
 // very important!!
 #[repr(C)]
-struct PerfReader {
+#[derive(Debug)]
+pub struct PerfReader {
     ptr: *mut perf_reader,
 }
 
@@ -43,11 +44,7 @@ impl Drop for PerfReader {
 
 #[allow(dead_code)]
 pub struct PerfMap {
-    // table and callbacks are just in here to make sure the data stays owned/alive
-    // TODO: improve this API
-    table: Table,
-    readers: Vec<PerfReader>,
-    callbacks: Vec<Box<PerfCallback>>,
+    pub readers: Vec<PerfReader>,
 }
 
 pub fn init_perf_map<F>(mut table: Table, cb: F) -> Result<PerfMap, Error>
@@ -63,15 +60,13 @@ where
     }
 
     let mut readers: Vec<PerfReader> = vec![];
-    let mut callbacks = vec![];
     let mut cur = Cursor::new(leaf);
 
     let cpus = cpuonline::get()?;
     for cpu in cpus.iter() {
-        let (mut reader, callback) = open_perf_buffer(*cpu, cb())?;
+        let mut reader = open_perf_buffer(*cpu, cb())?;
         let perf_fd = reader.fd() as u32;
         readers.push(reader);
-        callbacks.push(callback);
 
         let mut key = vec![];
         key.write_u32::<NativeEndian>(*cpu as u32)?;
@@ -81,11 +76,7 @@ where
             .context("Unable to initialize perf map")?;
         cur.set_position(0);
     }
-    Ok(PerfMap {
-        table,
-        readers,
-        callbacks,
-    })
+    Ok(PerfMap { readers })
 }
 
 impl PerfMap {
@@ -100,16 +91,13 @@ impl PerfMap {
     }
 }
 
-fn open_perf_buffer(
-    cpu: usize,
-    raw_cb: Box<dyn FnMut(&[u8]) + Send>,
-) -> Result<(PerfReader, Box<PerfCallback>), Error> {
-    let mut callback = Box::new(PerfCallback { raw_cb });
+fn open_perf_buffer(cpu: usize, raw_cb: Box<dyn FnMut(&[u8]) + Send>) -> Result<PerfReader, Error> {
+    let callback = Box::new(PerfCallback { raw_cb });
     let reader = unsafe {
         bpf_open_perf_buffer(
             Some(raw_callback),
             None,
-            callback.as_mut() as *mut _ as MutPointer,
+            Box::into_raw(callback) as MutPointer,
             -1, /* pid */
             cpu as i32,
             BPF_PERF_READER_PAGE_CNT,
@@ -118,10 +106,7 @@ fn open_perf_buffer(
     if reader.is_null() {
         return Err(format_err!("failed to open perf buffer"));
     }
-    Ok((
-        PerfReader {
-            ptr: reader as *mut perf_reader,
-        },
-        callback,
-    ))
+    Ok(PerfReader {
+        ptr: reader as *mut perf_reader,
+    })
 }


### PR DESCRIPTION
The problem I am trying to solve is to support poll multi perf buffer at once. (look at #49)
The changes are:

- add `perf_readers: Vec<PerfReader>` to `struct BPF` 
- use `Box::into_raw(callback)` to change callback's ownership to C code
- add `init_perf_map` and  `perf_map_poll` to `BPF` and keep old perf's API (can poll each perf buffer alone)
- add an example `tcpretrans` to show the new API's usage.
