### PR TITLE
add support for bcc 0.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
   - cd bcc
   - git checkout master
   - git pull
-  - git checkout remotes/origin/tag_v0.10.0
+  - git checkout 0fa419a64e71984d42f107c210d3d3f0cc82d59a
   - mkdir -p _build
   - cd _build
   - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
@@ -252,6 +252,36 @@ matrix:
         - git checkout master
         - git pull
         - git checkout remotes/origin/tag_v0.10.0
+        - mkdir -p _build
+        - cd _build
+        - cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+        - make
+        - sudo make install
+        - cd ../..
+        - cargo build --features $BCC
+        - cargo test --features $BCC
+        - cargo build --release --features $BCC
+        - cargo test --release --features $BCC
+        - cargo build --release --examples --features $BCC
+        - ls /lib/modules/*/build
+        - sudo target/release/examples/softirqs --interval 1 --windows 5
+        - sudo target/release/examples/runqlat --interval 1 --windows 5
+        - sudo target/release/examples/opensnoop --duration 5
+        - sudo target/release/examples/biosnoop --duration 5
+        - sudo target/release/examples/tcpretrans --duration 5
+    - os: linux
+      dist: bionic
+      rust: stable
+      env: BCC=v0_11_0 RUST_BACKTRACE=1
+      script:
+        - sudo apt-get update
+        - sudo apt-get install linux-headers-`uname -r`
+        - sudo apt-get -y install bison build-essential cmake flex git libedit-dev libllvm6.0 llvm-6.0-dev libclang-6.0-dev python zlib1g-dev libelf-dev libfl-dev
+        - git clone https://github.com/iovisor/bcc || true
+        - cd bcc
+        - git checkout master
+        - git pull
+        - git checkout 0fa419a64e71984d42f107c210d3d3f0cc82d59a
         - mkdir -p _build
         - cd _build
         - cmake .. -DCMAKE_INSTALL_PREFIX=/usr

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/rust-bpf/rust-bcc"
 edition = '2018'
 
 [dependencies]
-bcc-sys = "0.10.0"
+bcc-sys = "0.11.0"
 byteorder = "1.3.1"
 failure = "0.1.5"
 libc = "0.2.55"
@@ -26,11 +26,13 @@ chrono = "0.4"
 
 [features]
 static = ["bcc-sys/static"]
-v0_4_0 = ["bcc-sys/v0_4_0"]
-v0_5_0 = ["bcc-sys/v0_5_0"]
-v0_6_0 = ["bcc-sys/v0_6_0"]
-v0_6_1 = ["bcc-sys/v0_6_1"]
-v0_7_0 = ["bcc-sys/v0_7_0"]
-v0_8_0 = ["bcc-sys/v0_8_0"]
-v0_9_0 = ["bcc-sys/v0_9_0"]
-v0_10_0 = ["bcc-sys/v0_10_0"]
+specific = []
+v0_4_0 = ["bcc-sys/v0_4_0", "specific"]
+v0_5_0 = ["bcc-sys/v0_5_0", "specific"]
+v0_6_0 = ["bcc-sys/v0_6_0", "specific"]
+v0_6_1 = ["bcc-sys/v0_6_1", "specific"]
+v0_7_0 = ["bcc-sys/v0_7_0", "specific"]
+v0_8_0 = ["bcc-sys/v0_8_0", "specific"]
+v0_9_0 = ["bcc-sys/v0_9_0", "specific"]
+v0_10_0 = ["bcc-sys/v0_10_0", "specific"]
+v0_11_0 = ["bcc-sys/v0_11_0", "specific"]

--- a/examples/softirqs_0_4_0.c
+++ b/examples/softirqs_0_4_0.c
@@ -28,6 +28,7 @@ int softirq_entry(struct tracepoint__irq__softirq_entry *args)
     return 0;
 }
 
+// for use with bcc 0.4.0 - 0.6.1
 int softirq_exit(struct tracepoint__irq__softirq_exit *args)
 {
     u64 delta;

--- a/examples/softirqs_0_7_0.c
+++ b/examples/softirqs_0_7_0.c
@@ -1,0 +1,53 @@
+#include <uapi/linux/ptrace.h>
+
+// This code is taken from: https://github.com/iovisor/bcc/tools/softirqs.py
+//
+// Copyright (c) 2015 Brendan Gregg.
+// Licensed under the Apache License, Version 2.0 (the "License")
+
+typedef struct irq_key {
+    u32 vec;
+    u64 slot;
+} irq_key_t;
+
+typedef struct account_val {
+    u64 ts;
+    u32 vec;
+} account_val_t;
+
+BPF_HASH(start, u32, account_val_t);
+BPF_HISTOGRAM(dist, irq_key_t);
+
+int softirq_entry(struct tracepoint__irq__softirq_entry *args)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    account_val_t val = {};
+    val.ts = bpf_ktime_get_ns();
+    val.vec = args->vec;
+    start.update(&pid, &val);
+    return 0;
+}
+
+// for use with bcc 0.7.0 and up
+int softirq_exit(struct tracepoint__irq__softirq_exit *args)
+{
+    u64 delta;
+    u32 vec;
+    u32 pid = bpf_get_current_pid_tgid();
+    account_val_t *valp;
+    irq_key_t key = {0};
+    // fetch timestamp and calculate delta
+    valp = start.lookup(&pid);
+    if (valp == 0) {
+        return 0;   // missed start
+    }
+    delta = bpf_ktime_get_ns() - valp->ts;
+    vec = valp->vec;
+
+    // store as sum
+    key.vec = valp->vec;
+    dist.increment(key, delta);
+
+    start.delete(&pid);
+    return 0;
+}

--- a/src/core/kprobe/mod.rs
+++ b/src/core/kprobe/mod.rs
@@ -23,31 +23,15 @@ pub use v0_6_0::*;
 #[cfg(any(
     feature = "v0_9_0",
     feature = "v0_10_0",
-    not(any(
-        feature = "v0_4_0",
-        feature = "v0_5_0",
-        feature = "v0_6_0",
-        feature = "v0_6_1",
-        feature = "v0_7_0",
-        feature = "v0_8_0",
-        feature = "v0_9_0",
-        feature = "v0_10_0",
-    )),
+    feature = "v0_11_0",
+    not(feature = "specific"),
 ))]
 mod v0_9_0;
 
 #[cfg(any(
     feature = "v0_9_0",
     feature = "v0_10_0",
-    not(any(
-        feature = "v0_4_0",
-        feature = "v0_5_0",
-        feature = "v0_6_0",
-        feature = "v0_6_1",
-        feature = "v0_7_0",
-        feature = "v0_8_0",
-        feature = "v0_9_0",
-        feature = "v0_10_0",
-    )),
+    feature = "v0_11_0",
+    not(feature = "specific"),
 ))]
 pub use v0_9_0::*;

--- a/src/core/tracepoint/mod.rs
+++ b/src/core/tracepoint/mod.rs
@@ -11,16 +11,8 @@ pub use v0_4_0::*;
     feature = "v0_8_0",
     feature = "v0_9_0",
     feature = "v0_10_0",
-    not(any(
-        feature = "v0_4_0",
-        feature = "v0_5_0",
-        feature = "v0_6_0",
-        feature = "v0_6_1",
-        feature = "v0_7_0",
-        feature = "v0_8_0",
-        feature = "v0_9_0",
-        feature = "v0_10_0",
-    )),
+    feature = "v0_11_0",
+    not(feature = "specific"),
 ))]
 mod v0_6_0;
 
@@ -31,15 +23,7 @@ mod v0_6_0;
     feature = "v0_8_0",
     feature = "v0_9_0",
     feature = "v0_10_0",
-    not(any(
-        feature = "v0_4_0",
-        feature = "v0_5_0",
-        feature = "v0_6_0",
-        feature = "v0_6_1",
-        feature = "v0_7_0",
-        feature = "v0_8_0",
-        feature = "v0_9_0",
-        feature = "v0_10_0",
-    )),
+    feature = "v0_11_0",
+    not(feature = "specific"),
 ))]
 pub use v0_6_0::*;

--- a/src/core/uprobe/mod.rs
+++ b/src/core/uprobe/mod.rs
@@ -11,16 +11,8 @@ pub use v0_4_0::*;
     feature = "v0_8_0",
     feature = "v0_9_0",
     feature = "v0_10_0",
-    not(any(
-        feature = "v0_4_0",
-        feature = "v0_5_0",
-        feature = "v0_6_0",
-        feature = "v0_6_1",
-        feature = "v0_7_0",
-        feature = "v0_8_0",
-        feature = "v0_9_0",
-        feature = "v0_10_0",
-    )),
+    feature = "v0_11_0",
+    not(feature = "specific"),
 ))]
 mod v0_6_0;
 
@@ -31,15 +23,7 @@ mod v0_6_0;
     feature = "v0_8_0",
     feature = "v0_9_0",
     feature = "v0_10_0",
-    not(any(
-        feature = "v0_4_0",
-        feature = "v0_5_0",
-        feature = "v0_6_0",
-        feature = "v0_6_1",
-        feature = "v0_7_0",
-        feature = "v0_8_0",
-        feature = "v0_9_0",
-        feature = "v0_10_0",
-    )),
+    feature = "v0_11_0",
+    not(feature = "specific"),
 ))]
 pub use v0_6_0::*;


### PR DESCRIPTION
briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this
  change?)

Support the latest bcc versions

* what changes does this pull request make?

Updates bcc-sys to the latest version, adds features to support bcc 0.11.0, and makes 0.11.0 the new default version

* are there any non-obvious implications of these changes? (does it break compatibility with previous
  versions, etc)

Updating to the latest version of this crate requires that the user update bcc to 0.11.0 or begins to use feature flags to pin bcc to a prior version.