### PR TITLE
Add page_cnt variable for perf table

### DIFF
--- a/examples/biosnoop.rs
+++ b/examples/biosnoop.rs
@@ -1,5 +1,5 @@
 use bcc::core::BPF;
-use bcc::perf::init_perf_map;
+use bcc::perf::{init_perf_map, BPF_PERF_READER_PAGE_CNT};
 use clap::{App, Arg};
 use failure::Error;
 
@@ -71,7 +71,7 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
     }
     // the "events" table is where the "open file" events get sent
     let table = bpf.table("events");
-    let mut perf_map = init_perf_map(table, perf_data_callback)?;
+    let mut perf_map = init_perf_map(table, perf_data_callback, BPF_PERF_READER_PAGE_CNT)?;
     // print a header
     println!(
         "{:<-11} {:<-14} {:<-6} {:<-7} {:<-1} {:<-10} {:>-7}",

--- a/examples/opensnoop.rs
+++ b/examples/opensnoop.rs
@@ -4,7 +4,7 @@ extern crate failure;
 extern crate libc;
 
 use bcc::core::BPF;
-use bcc::perf::init_perf_map;
+use bcc::perf::{init_perf_map, BPF_PERF_READER_PAGE_CNT};
 use clap::{App, Arg};
 use failure::Error;
 
@@ -61,7 +61,7 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
     // the "events" table is where the "open file" events get sent
     let table = module.table("events");
     // install a callback to print out file open events when they happen
-    let mut perf_map = init_perf_map(table, perf_data_callback)?;
+    let mut perf_map = init_perf_map(table, perf_data_callback, BPF_PERF_READER_PAGE_CNT)?;
     // print a header
     println!("{:-7} {:-16} {}", "PID", "COMM", "FILENAME");
     let start = std::time::Instant::now();

--- a/examples/tcpretrans.rs
+++ b/examples/tcpretrans.rs
@@ -1,4 +1,5 @@
 use bcc::core::BPF;
+use bcc::perf::BPF_PERF_READER_PAGE_CNT;
 extern crate chrono;
 use chrono::Utc;
 use clap::{App, Arg};
@@ -61,9 +62,9 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
     bpf.attach_kprobe("tcp_retransmit_skb", trace_retransmit)?;
 
     let table = bpf.table("ipv4_events");
-    bpf.init_perf_map(table, print_ipv4_event)?;
+    bpf.init_perf_map(table, print_ipv4_event, BPF_PERF_READER_PAGE_CNT)?;
     let table = bpf.table("ipv6_events");
-    bpf.init_perf_map(table, print_ipv6_event)?;
+    bpf.init_perf_map(table, print_ipv6_event, BPF_PERF_READER_PAGE_CNT)?;
 
     println!(
         "{:<-8} {:<-6} {:<-2} {:<-20} {:>-1} {:<-20} {:<-4}",

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -373,11 +373,11 @@ impl BPF {
             || self.ksymname("bpf_get_raw_tracepoint").is_ok()
     }
 
-    pub fn init_perf_map<F>(&mut self, table: Table, cb: F) -> Result<(), Error>
+    pub fn init_perf_map<F>(&mut self, table: Table, cb: F, page_cnt: i32) -> Result<(), Error>
     where
         F: Fn() -> Box<dyn FnMut(&[u8]) + Send>,
     {
-        let perf_map = perf::init_perf_map(table, cb)?;
+        let perf_map = perf::init_perf_map(table, cb, page_cnt)?;
         self.perf_readers.extend(perf_map.readers);
         Ok(())
     }


### PR DESCRIPTION
briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this
  change?)
Allow for a configurable page_cnt parameter for larger ringbuffer allocation in bcc perf's implementation

* what changes does this pull request make?
Introduces a new parameter for `init_perf_map` to allow a user to provide the `page_cnt` size

* are there any non-obvious implications of these changes? (does it break compatibility with previous
  versions, etc)
This breaks API compat with the `init_perf_map` since it adds a new variable, however this may be possible to mitigate with conditional compilation features + targets.


Ref: https://github.com/iovisor/bcc/blob/149c1c8857652997622fc2a30747a60e0c9c17dc/src/python/bcc/table.py#L674