### PR TITLE
use atomic pointers to make BPF Send and Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -871,7 +871,7 @@ matrix:
       env: BCC=v0_9_0 RUST_BACKTRACE=1
       script:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-        - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list
+        - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" | sudo tee -a /etc/apt/sources.list
         - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
         - sudo apt-get update
         - sudo apt-get install linux-headers-`uname -r`
@@ -902,7 +902,7 @@ matrix:
       env: BCC=v0_10_0 RUST_BACKTRACE=1
       script:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-        - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list
+        - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" | sudo tee -a /etc/apt/sources.list
         - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
         - sudo apt-get update
         - sudo apt-get install linux-headers-`uname -r`
@@ -933,7 +933,7 @@ matrix:
       env: BCC=v0_11_0 RUST_BACKTRACE=1
       script:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-        - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list
+        - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" | sudo tee -a /etc/apt/sources.list
         - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
         - sudo apt-get update
         - sudo apt-get install linux-headers-`uname -r`
@@ -964,7 +964,7 @@ matrix:
       env: BCC=v0_12_0 RUST_BACKTRACE=1
       script:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-        - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list
+        - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" | sudo tee -a /etc/apt/sources.list
         - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
         - sudo apt-get update
         - sudo apt-get install linux-headers-`uname -r`
@@ -995,7 +995,7 @@ matrix:
       env: RUST_BACKTRACE=1
       script:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-        - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list
+        - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" | sudo tee -a /etc/apt/sources.list
         - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
         - sudo apt-get update
         - sudo apt-get install linux-headers-`uname -r`

--- a/examples/runqlat.rs
+++ b/examples/runqlat.rs
@@ -10,18 +10,17 @@ use std::{mem, thread, time};
 //
 // Based on: https://github.com/iovisor/bcc/blob/master/tools/runqlat.py
 
-#[cfg(any(
-    feature = "v0_4_0",
-    feature = "v0_5_0",
-))]
+#[cfg(any(feature = "v0_4_0", feature = "v0_5_0",))]
 fn attach_events(bpf: &mut BPF) {
     let trace_run = bpf.load_kprobe("trace_run").unwrap();
     let trace_ttwu_do_wakeup = bpf.load_kprobe("trace_ttwu_do_wakeup").unwrap();
     let trace_wake_up_new_task = bpf.load_kprobe("trace_wake_up_new_task").unwrap();
 
     bpf.attach_kprobe("finish_task_switch", trace_run).unwrap();
-    bpf.attach_kprobe("wake_up_new_task", trace_wake_up_new_task).unwrap();
-    bpf.attach_kprobe("ttwu_do_wakeup", trace_ttwu_do_wakeup).unwrap();
+    bpf.attach_kprobe("wake_up_new_task", trace_wake_up_new_task)
+        .unwrap();
+    bpf.attach_kprobe("ttwu_do_wakeup", trace_ttwu_do_wakeup)
+        .unwrap();
 }
 
 #[cfg(any(
@@ -41,9 +40,12 @@ fn attach_events(bpf: &mut BPF) {
         let raw_tp_sched_wakeup_new = bpf.load_raw_tracepoint("raw_tp__sched_wakeup_new").unwrap();
         let raw_tp_sched_switch = bpf.load_raw_tracepoint("raw_tp__sched_switch").unwrap();
 
-        bpf.attach_raw_tracepoint("sched_wakeup", raw_tp_sched_wakeup).unwrap();
-        bpf.attach_raw_tracepoint("sched_wakeup_new", raw_tp_sched_wakeup_new).unwrap();
-        bpf.attach_raw_tracepoint("sched_switch", raw_tp_sched_switch).unwrap();
+        bpf.attach_raw_tracepoint("sched_wakeup", raw_tp_sched_wakeup)
+            .unwrap();
+        bpf.attach_raw_tracepoint("sched_wakeup_new", raw_tp_sched_wakeup_new)
+            .unwrap();
+        bpf.attach_raw_tracepoint("sched_switch", raw_tp_sched_switch)
+            .unwrap();
     } else {
         // load + attach kprobes!
         let trace_run = bpf.load_kprobe("trace_run").unwrap();
@@ -51,9 +53,11 @@ fn attach_events(bpf: &mut BPF) {
         let trace_wake_up_new_task = bpf.load_kprobe("trace_wake_up_new_task").unwrap();
 
         bpf.attach_kprobe("finish_task_switch", trace_run).unwrap();
-        bpf.attach_kprobe("wake_up_new_task", trace_wake_up_new_task).unwrap();
-        bpf.attach_kprobe("ttwu_do_wakeup", trace_ttwu_do_wakeup).unwrap();
-     }
+        bpf.attach_kprobe("wake_up_new_task", trace_wake_up_new_task)
+            .unwrap();
+        bpf.attach_kprobe("ttwu_do_wakeup", trace_ttwu_do_wakeup)
+            .unwrap();
+    }
 }
 
 fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {

--- a/examples/softirqs.rs
+++ b/examples/softirqs.rs
@@ -118,10 +118,10 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
     // load + attach tracepoints!
     let softirq_entry = module.load_tracepoint("softirq_entry")?;
     let softirq_exit = module.load_tracepoint("softirq_exit")?;
-    
+
     module.attach_tracepoint("irq", "softirq_entry", softirq_entry)?;
     module.attach_tracepoint("irq", "softirq_exit", softirq_exit)?;
-    
+
     let table = module.table("dist");
     let mut window = 0;
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -133,7 +133,7 @@ impl BPF {
     pub fn table(&self, name: &str) -> Table {
         // TODO: clean up this unwrap (and all the rest in this file)
         let cname = CString::new(name).unwrap();
-        let id = unsafe { bpf_table_id(self.p.load(Ordering::SeqCst), cname.as_ptr()) };
+        let id = unsafe { bpf_table_id(self.ptr(), cname.as_ptr()) };
         Table::new(id, self.ptr())
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -67,7 +67,7 @@ impl BPF {
         }
 
         Ok(BPF {
-            p: ptr,
+            p: AtomicPtr::new(ptr),
             uprobes: HashSet::new(),
             kprobes: HashSet::new(),
             tracepoints: HashSet::new(),
@@ -88,7 +88,7 @@ impl BPF {
         }
 
         Ok(BPF {
-            p: ptr,
+            p: AtomicPtr::new(ptr),
             uprobes: HashSet::new(),
             kprobes: HashSet::new(),
             tracepoints: HashSet::new(),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -78,10 +78,7 @@ impl BPF {
     }
 
     // 0.9.0 changes the API for bpf_module_create_c_from_string()
-    #[cfg(any(
-        feature = "v0_9_0",
-        feature = "v0_10_0",
-    ))]
+    #[cfg(any(feature = "v0_9_0", feature = "v0_10_0",))]
     pub fn new(code: &str) -> Result<BPF, Error> {
         let cs = CString::new(code)?;
         let ptr =
@@ -102,15 +99,19 @@ impl BPF {
     }
 
     // 0.11.0 changes the API for bpf_module_create_c_from_string()
-    #[cfg(any(
-        feature = "v0_11_0",
-        feature = "v0_12_0",
-        not(feature = "specific"),
-    ))]
+    #[cfg(any(feature = "v0_11_0", feature = "v0_12_0", not(feature = "specific"),))]
     pub fn new(code: &str) -> Result<BPF, Error> {
         let cs = CString::new(code)?;
-        let ptr =
-            unsafe { bpf_module_create_c_from_string(cs.as_ptr(), 2, ptr::null_mut(), 0, true, ptr::null_mut()) };
+        let ptr = unsafe {
+            bpf_module_create_c_from_string(
+                cs.as_ptr(),
+                2,
+                ptr::null_mut(),
+                0,
+                true,
+                ptr::null_mut(),
+            )
+        };
         if ptr.is_null() {
             return Err(format_err!("couldn't create BPF program"));
         }
@@ -179,7 +180,8 @@ impl BPF {
     ) -> Result<File, Error> {
         let cname = CString::new(name).unwrap();
         unsafe {
-            let start: *mut bpf_insn = bpf_function_start(self.ptr(), cname.as_ptr()) as *mut bpf_insn;
+            let start: *mut bpf_insn =
+                bpf_function_start(self.ptr(), cname.as_ptr()) as *mut bpf_insn;
             let size = bpf_function_size(self.ptr(), cname.as_ptr()) as i32;
             let license = bpf_module_license(self.ptr());
             let version = bpf_module_kern_version(self.ptr());
@@ -222,7 +224,8 @@ impl BPF {
     ) -> Result<File, Error> {
         let cname = CString::new(name).unwrap();
         unsafe {
-            let start: *mut bpf_insn = bpf_function_start(self.ptr(), cname.as_ptr()) as *mut bpf_insn;
+            let start: *mut bpf_insn =
+                bpf_function_start(self.ptr(), cname.as_ptr()) as *mut bpf_insn;
             let size = bpf_function_size(self.ptr(), cname.as_ptr()) as i32;
             let license = bpf_module_license(self.ptr());
             let version = bpf_module_kern_version(self.ptr());
@@ -267,7 +270,8 @@ impl BPF {
     ) -> Result<File, Error> {
         let cname = CString::new(name).unwrap();
         unsafe {
-            let start: *mut bpf_insn = bpf_function_start(self.ptr(), cname.as_ptr()) as *mut bpf_insn;
+            let start: *mut bpf_insn =
+                bpf_function_start(self.ptr(), cname.as_ptr()) as *mut bpf_insn;
             let size = bpf_function_size(self.ptr(), cname.as_ptr()) as i32;
             let license = bpf_module_license(self.ptr());
             let version = bpf_module_kern_version(self.ptr());

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,1 +1,1 @@
-pub type MutPointer = *mut std::os::raw::c_void;
+pub type MutPointer = *mut core::ffi::c_void;


### PR DESCRIPTION
Currently, the BPF struct is marked `!Send` and `!Sync` due to our use of bare pointers.

By using the `AtomicPtr` type, we now make BPF both `Send` and `Sync`. This is particularly useful if we want to use BPF within a multithreaded async executor, like Tokio. I have also fixed the llvm 10 builds in Travis by updating the repository name to reflect changes on llvm repo.

No non-obvious implications. Changes are internal to the structures and does not change the surface API.
