### PR TITLE
[RFC] Switched error handling to anyhow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ byteorder = "1.3.4"
 failure = "0.1.7"
 libc = "0.2.68"
 regex = "1.3.5"
-thiserror = "1.0.14"
 
 [dev-dependencies]
 clap = "2.33.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ homepage = "https://github.com/rust-bpf/rust-bcc"
 edition = '2018'
 
 [dependencies]
+anyhow = "1.0.28"
 bcc-sys = "0.13.0"
 byteorder = "1.3.4"
 failure = "0.1.7"
 libc = "0.2.68"
 regex = "1.3.5"
+thiserror = "1.0.14"
 
 [dev-dependencies]
 clap = "2.33.0"

--- a/examples/biosnoop.rs
+++ b/examples/biosnoop.rs
@@ -1,7 +1,7 @@
+use anyhow::Result;
 use bcc::core::BPF;
 use bcc::perf::init_perf_map;
 use clap::{App, Arg};
-use failure::Error;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::ptr;
@@ -24,7 +24,7 @@ struct data_t {
     name: [u8; 16],
 }
 
-fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+fn do_main(runnable: Arc<AtomicBool>) -> Result<()> {
     let matches = App::new("biosnoop")
         .about("Trace block I/O")
         .arg(
@@ -134,7 +134,6 @@ fn main() {
 
     if let Err(x) = do_main(runnable) {
         eprintln!("Error: {}", x);
-        eprintln!("{}", x.backtrace());
         std::process::exit(1);
     }
 }

--- a/examples/opensnoop.rs
+++ b/examples/opensnoop.rs
@@ -3,10 +3,10 @@ extern crate byteorder;
 extern crate failure;
 extern crate libc;
 
+use anyhow::Result;
 use bcc::core::BPF;
 use bcc::perf::init_perf_map;
 use clap::{App, Arg};
-use failure::Error;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::ptr;
@@ -34,7 +34,7 @@ struct data_t {
     fname: [u8; 255], // NAME_MAX
 }
 
-fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+fn do_main(runnable: Arc<AtomicBool>) -> Result<()> {
     let matches = App::new("opensnoop")
         .about("Prints out filename + PID every time a file is opened")
         .arg(
@@ -112,7 +112,6 @@ fn main() {
     match do_main(runnable) {
         Err(x) => {
             eprintln!("Error: {}", x);
-            eprintln!("{}", x.backtrace());
             std::process::exit(1);
         }
         _ => {}

--- a/examples/runqlat.rs
+++ b/examples/runqlat.rs
@@ -1,6 +1,6 @@
+use anyhow::Result;
 use bcc::core::BPF;
 use clap::{App, Arg};
-use failure::Error;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -50,7 +50,7 @@ fn attach_events(bpf: &mut BPF) {
     }
 }
 
-fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+fn do_main(runnable: Arc<AtomicBool>) -> Result<()> {
     let matches = App::new("runqlat")
         .about("Reports distribution of scheduler latency")
         .arg(
@@ -131,7 +131,6 @@ fn main() {
     match do_main(runnable) {
         Err(x) => {
             eprintln!("Error: {}", x);
-            eprintln!("{}", x.backtrace());
             std::process::exit(1);
         }
         _ => {}

--- a/examples/softirqs.rs
+++ b/examples/softirqs.rs
@@ -1,6 +1,6 @@
+use anyhow::Result;
 use bcc::core::BPF;
 use clap::{App, Arg};
-use failure::Error;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -73,7 +73,7 @@ impl fmt::Display for SoftIRQ {
     }
 }
 
-fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+fn do_main(runnable: Arc<AtomicBool>) -> Result<()> {
     let matches = App::new("softirqs")
         .about("Reports time spent in IRQ Handlers")
         .arg(
@@ -169,7 +169,6 @@ fn main() {
     match do_main(runnable) {
         Err(x) => {
             eprintln!("Error: {}", x);
-            eprintln!("{}", x.backtrace());
             std::process::exit(1);
         }
         _ => {}

--- a/examples/strlen.rs
+++ b/examples/strlen.rs
@@ -3,15 +3,15 @@ extern crate byteorder;
 extern crate failure;
 extern crate libc;
 
+use anyhow::Result;
 use bcc::core::BPF;
 use byteorder::{NativeEndian, ReadBytesExt};
-use failure::Error;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::io::Cursor;
 use std::sync::Arc;
 
-fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+fn do_main(runnable: Arc<AtomicBool>) -> Result<()> {
     let code = "
 #include <uapi/linux/ptrace.h>
 
@@ -75,7 +75,6 @@ fn main() {
     match do_main(runnable) {
         Err(x) => {
             eprintln!("Error: {}", x);
-            eprintln!("{}", x.backtrace());
             std::process::exit(1);
         }
         _ => {}

--- a/examples/tcpretrans.rs
+++ b/examples/tcpretrans.rs
@@ -1,8 +1,8 @@
 use bcc::core::BPF;
 extern crate chrono;
+use anyhow::Result;
 use chrono::Utc;
 use clap::{App, Arg};
-use failure::Error;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::net::Ipv4Addr;
@@ -38,7 +38,7 @@ struct ipv6_data_t {
     type_: u64,
 }
 
-fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+fn do_main(runnable: Arc<AtomicBool>) -> Result<()> {
     let matches = App::new("biosnoop")
         .arg(
             Arg::with_name("duration")
@@ -131,7 +131,6 @@ fn main() {
 
     if let Err(x) = do_main(runnable) {
         eprintln!("Error: {}", x);
-        eprintln!("{}", x.backtrace());
         std::process::exit(1);
     }
 }

--- a/src/core/kprobe/v0_4_0.rs
+++ b/src/core/kprobe/v0_4_0.rs
@@ -1,7 +1,7 @@
+use anyhow::{self, bail, Result};
 use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_ENTRY as BPF_PROBE_ENTRY;
 use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_RETURN as BPF_PROBE_RETURN;
 use bcc_sys::bccapi::*;
-use failure::*;
 
 use crate::core::make_alphanumeric;
 use crate::types::MutPointer;
@@ -23,9 +23,9 @@ pub struct Kprobe {
 }
 
 impl Kprobe {
-    fn new(name: &str, attach_type: u32, function: &str, code: File) -> Result<Self, Error> {
+    fn new(name: &str, attach_type: u32, function: &str, code: File) -> Result<Self> {
         let cname =
-            CString::new(name).map_err(|_| format_err!("Nul byte in Kprobe name: {}", name))?;
+            CString::new(name).map_err(|_| anyhow::anyhow!("Nul byte in Kprobe name: {}", name))?;
         let cfunction = CString::new(function)
             .map_err(|_| format_err!("Nul byte in Kprobe function: {}", function))?;
         let (pid, cpu, group_fd) = (-1, 0, -1);
@@ -43,7 +43,7 @@ impl Kprobe {
             )
         };
         if ptr.is_null() {
-            Err(format_err!("Failed to attach Kprobe: {}", name))
+            bail!(anyhow::anyhow!("Failed to attach Kprobe: {}", name))
         } else {
             Ok(Self {
                 p: ptr,
@@ -53,19 +53,19 @@ impl Kprobe {
         }
     }
 
-    pub fn attach_kprobe(function: &str, code: File) -> Result<Self, Error> {
+    pub fn attach_kprobe(function: &str, code: File) -> Result<Self> {
         let name = format!("p_{}", &make_alphanumeric(function));
         Kprobe::new(&name, BPF_PROBE_ENTRY, function, code)
-            .map_err(|_| format_err!("Failed to attach Kprobe: {}", name))
+            .map_err(|_| anyhow::anyhow!("Failed to attach Kprobe: {}", name))
     }
 
-    pub fn attach_kretprobe(function: &str, code: File) -> Result<Self, Error> {
+    pub fn attach_kretprobe(function: &str, code: File) -> Result<Self> {
         let name = format!("r_{}", &make_alphanumeric(function));
         Kprobe::new(&name, BPF_PROBE_RETURN, function, code)
-            .map_err(|_| format_err!("Failed to attach Kretprobe: {}", name))
+            .map_err(|_| anyhow::anyhow!("Failed to attach Kretprobe: {}", name))
     }
 
-    pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>, Error> {
+    pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>> {
         let mut fns: Vec<String> = vec![];
 
         enum Section {

--- a/src/core/kprobe/v0_6_0.rs
+++ b/src/core/kprobe/v0_6_0.rs
@@ -1,7 +1,7 @@
+use anyhow::{self, bail, Result};
 use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_ENTRY as BPF_PROBE_ENTRY;
 use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_RETURN as BPF_PROBE_RETURN;
 use bcc_sys::bccapi::*;
-use failure::*;
 
 use crate::core::make_alphanumeric;
 
@@ -21,11 +21,11 @@ pub struct Kprobe {
 }
 
 impl Kprobe {
-    fn new(name: &str, attach_type: u32, function: &str, code: File) -> Result<Self, Error> {
+    fn new(name: &str, attach_type: u32, function: &str, code: File) -> Result<Self> {
         let cname =
             CString::new(name).map_err(|_| format_err!("Nul byte in Kprobe name: {}", name))?;
         let cfunction = CString::new(function)
-            .map_err(|_| format_err!("Nul byte in Kprobe function: {}", function))?;
+            .map_err(|_| anyhow::anyhow!("Nul byte in Kprobe function: {}", function))?;
         let ptr = unsafe {
             bpf_attach_kprobe(
                 code.as_raw_fd(),
@@ -36,7 +36,7 @@ impl Kprobe {
             )
         };
         if ptr < 0 {
-            Err(format_err!("Failed to attach Kprobe: {}", name))
+            Err(anyhow::anyhow!("Failed to attach Kprobe: {}", name))
         } else {
             Ok(Self {
                 p: ptr,
@@ -46,19 +46,19 @@ impl Kprobe {
         }
     }
 
-    pub fn attach_kprobe(function: &str, code: File) -> Result<Self, Error> {
+    pub fn attach_kprobe(function: &str, code: File) -> Result<Self> {
         let name = format!("p_{}", &make_alphanumeric(function));
         Kprobe::new(&name, BPF_PROBE_ENTRY, function, code)
-            .map_err(|_| format_err!("Failed to attach Kprobe: {}", name))
+            .map_err(|_| anyhow::anyhow!("Failed to attach Kprobe: {}", name))
     }
 
-    pub fn attach_kretprobe(function: &str, code: File) -> Result<Self, Error> {
+    pub fn attach_kretprobe(function: &str, code: File) -> Result<Self> {
         let name = format!("r_{}", &make_alphanumeric(function));
         Kprobe::new(&name, BPF_PROBE_RETURN, function, code)
-            .map_err(|_| format_err!("Failed to attach Kretprobe: {}", name))
+            .map_err(|_| anyhow::anyhow!("Failed to attach Kretprobe: {}", name))
     }
 
-    pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>, Error> {
+    pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>> {
         let mut fns: Vec<String> = vec![];
 
         enum Section {

--- a/src/core/raw_tracepoint/v0_6_0.rs
+++ b/src/core/raw_tracepoint/v0_6_0.rs
@@ -1,5 +1,5 @@
+use anyhow::{self, Result};
 use bcc_sys::bccapi::*;
-use failure::*;
 
 use std::ffi::CString;
 use std::fs::File;
@@ -14,12 +14,12 @@ pub struct RawTracepoint {
 }
 
 impl RawTracepoint {
-    pub fn attach_raw_tracepoint(name: &str, file: File) -> Result<Self, Error> {
-        let cname =
-            CString::new(name).map_err(|_| format_err!("Nul byte in Tracepoint name: {}", name))?;
+    pub fn attach_raw_tracepoint(name: &str, file: File) -> Result<Self> {
+        let cname = CString::new(name)
+            .map_err(|_| anyhow::anyhow!("Nul byte in Tracepoint name: {}", name))?;
         let ptr = unsafe { bpf_attach_raw_tracepoint(file.as_raw_fd(), cname.as_ptr() as *mut _) };
         if ptr < 0 {
-            Err(format_err!("Failed to attach raw tracepoint: {}", name))
+            Err(anyhow::anyhow!("Failed to attach raw tracepoint: {}", name))
         } else {
             Ok(Self {
                 name: cname,

--- a/src/core/tracepoint/v0_4_0.rs
+++ b/src/core/tracepoint/v0_4_0.rs
@@ -1,5 +1,5 @@
+use anyhow::{self, bail, Result};
 use bcc_sys::bccapi::*;
-use failure::*;
 
 use crate::types::MutPointer;
 
@@ -18,11 +18,11 @@ pub struct Tracepoint {
 }
 
 impl Tracepoint {
-    pub fn attach_tracepoint(subsys: &str, name: &str, file: File) -> Result<Self, Error> {
+    pub fn attach_tracepoint(subsys: &str, name: &str, file: File) -> Result<Self> {
         let cname =
             CString::new(name).map_err(|_| format_err!("Nul byte in Tracepoint name: {}", name))?;
         let csubsys = CString::new(subsys)
-            .map_err(|_| format_err!("Nul byte in Tracepoint subsys: {}", subsys))?;
+            .map_err(|_| anyhow::anyhow!("Nul byte in Tracepoint subsys: {}", subsys))?;
         // NOTE: BPF events are system-wide and do not support CPU filter
         let (pid, cpu, group_fd) = (-1, 0, -1);
         let ptr = unsafe {

--- a/src/core/tracepoint/v0_6_0.rs
+++ b/src/core/tracepoint/v0_6_0.rs
@@ -1,5 +1,5 @@
+use anyhow::{self, Result};
 use bcc_sys::bccapi::*;
-use failure::*;
 
 use std::ffi::CString;
 use std::fs::File;
@@ -15,15 +15,15 @@ pub struct Tracepoint {
 }
 
 impl Tracepoint {
-    pub fn attach_tracepoint(subsys: &str, name: &str, file: File) -> Result<Self, Error> {
-        let cname =
-            CString::new(name).map_err(|_| format_err!("Nul byte in Tracepoint name: {}", name))?;
+    pub fn attach_tracepoint(subsys: &str, name: &str, file: File) -> Result<Self> {
+        let cname = CString::new(name)
+            .map_err(|_| anyhow::anyhow!("Nul byte in Tracepoint name: {}", name))?;
         let csubsys = CString::new(subsys)
-            .map_err(|_| format_err!("Nul byte in Tracepoint subsys: {}", subsys))?;
+            .map_err(|_| anyhow::anyhow!("Nul byte in Tracepoint subsys: {}", subsys))?;
         let ptr =
             unsafe { bpf_attach_tracepoint(file.as_raw_fd(), csubsys.as_ptr(), cname.as_ptr()) };
         if ptr < 0 {
-            Err(format_err!(
+            Err(anyhow::anyhow!(
                 "Failed to attach tracepoint: {}:{}",
                 subsys,
                 name

--- a/src/core/uprobe/v0_4_0.rs
+++ b/src/core/uprobe/v0_4_0.rs
@@ -1,7 +1,7 @@
+use anyhow::{self, bail, Result};
 use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_ENTRY as BPF_PROBE_ENTRY;
 use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_RETURN as BPF_PROBE_RETURN;
 use bcc_sys::bccapi::*;
-use failure::*;
 
 use crate::core::make_alphanumeric;
 use crate::symbol;
@@ -28,11 +28,11 @@ impl Uprobe {
         addr: u64,
         file: File,
         pid: pid_t,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self> {
         let cname =
-            CString::new(name).map_err(|_| format_err!("Nul byte in Uprobe name: {}", name))?;
+            CString::new(name).map_err(|_| anyhow::anyhow!("Nul byte in Uprobe name: {}", name))?;
         let cpath =
-            CString::new(path).map_err(|_| format_err!("Nul byte in Uprobe path: {}", name))?;
+            CString::new(path).map_err(|_| anyhow::anyhow!("Nul byte in Uprobe path: {}", name))?;
         // TODO: maybe pass in the CPU & PID instead of
         let (cpu, group_fd) = (0, -1);
         let uprobe_ptr = unsafe {
@@ -50,7 +50,7 @@ impl Uprobe {
             )
         };
         if uprobe_ptr.is_null() {
-            Err(format_err!("Failed to attach Uprobe: {}", name))
+            Err(anyhow::anyhow!("Failed to attach Uprobe: {}", name))
         } else {
             Ok(Self {
                 code_fd: file,
@@ -60,17 +60,12 @@ impl Uprobe {
         }
     }
 
-    pub fn attach_uprobe(
-        binary_path: &str,
-        symbol: &str,
-        code: File,
-        pid: pid_t,
-    ) -> Result<Self, Error> {
+    pub fn attach_uprobe(binary_path: &str, symbol: &str, code: File, pid: pid_t) -> Result<Self> {
         let (path, addr) = symbol::resolve_symbol_path(binary_path, symbol, 0x0, pid)?;
         let alpha_path = make_alphanumeric(&path);
         let ev_name = format!("r_{}_0x{:x}", &alpha_path, addr);
         Uprobe::new(&ev_name, BPF_PROBE_ENTRY, &path, addr, code, pid)
-            .map_err(|_| format_err!("Failed to attach Uprobe to binary: {}", binary_path))
+            .map_err(|_| anyhow::anyhow!("Failed to attach Uprobe to binary: {}", binary_path))
     }
 
     pub fn attach_uretprobe(
@@ -78,12 +73,12 @@ impl Uprobe {
         symbol: &str,
         code: File,
         pid: pid_t,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self> {
         let (path, addr) = symbol::resolve_symbol_path(binary_path, symbol, 0x0, pid)?;
         let alpha_path = make_alphanumeric(&path);
         let ev_name = format!("r_{}_0x{:x}", &alpha_path, addr);
         Uprobe::new(&ev_name, BPF_PROBE_RETURN, &path, addr, code, pid)
-            .map_err(|_| format_err!("Failed to attach Uretprobe to binary: {}", binary_path))
+            .map_err(|_| anyhow::anyhow!("Failed to attach Uretprobe to binary: {}", binary_path))
     }
 }
 

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -1,5 +1,5 @@
+use anyhow::{self, Result};
 use bcc_sys::bccapi::*;
-use failure::*;
 use libc::free;
 
 use core::ffi::c_void;
@@ -14,7 +14,7 @@ pub fn resolve_symbol_path(
     symname: &str,
     addr: u64,
     pid: pid_t,
-) -> Result<(String, u64), Error> {
+) -> Result<(String, u64)> {
     let pid: pid_t = match pid {
         -1 => 0,
         x => x,
@@ -28,7 +28,7 @@ pub fn resolve_symname(
     symname: &str,
     addr: u64,
     pid: pid_t,
-) -> Result<(String, u64), Error> {
+) -> Result<(String, u64)> {
     let mut symbol = unsafe { mem::zeroed::<bcc_symbol>() };
     let cmodule = CString::new(module)?;
     let csymname = CString::new(symname)?;
@@ -44,7 +44,7 @@ pub fn resolve_symname(
         )
     };
     if res < 0 {
-        Err(format_err!(
+        Err(anyhow::anyhow!(
             "unable to locate symbol {} in module {}: {}",
             &symname,
             module,
@@ -75,7 +75,7 @@ impl SymbolCache {
         }
     }
 
-    pub fn resolve_name(&self, module: &str, name: &str) -> Result<u64, Error> {
+    pub fn resolve_name(&self, module: &str, name: &str) -> Result<u64> {
         let cmodule = CString::new(module)?;
         let cname = CString::new(name)?;
         let mut addr: u64 = 0;
@@ -89,7 +89,7 @@ impl SymbolCache {
             )
         };
         if res < 0 {
-            Err(format_err!(
+            Err(anyhow::anyhow!(
                 "unable to locate symbol {} in module {}: {}",
                 &name,
                 module,


### PR DESCRIPTION
As of rust 1.34+, many crates have switched to using anyhow for error handling. This is because anyhow provides support for returning any error implementing `std::error::Error`. This change basically replaces out all uses of the `failure` crate with `anyhow`. This could cause two potential issues:

1. Compatibility breakages, this will require clients to handle a completely new return type
2. Will add a hard dependency on rustc 1.34 for any clients

Overall though, I believe this change could be worth it for the upside of allowing clients to use any error type that implements `std::error::Error`.
