### PR TITLE
opensnoop.py moved to tools/

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ to match the expected version of bcc with the version you have installed on your
 ### Examples
 
 * [examples/strlen.rs](https://github.com/rust-bpf/rust-bcc/blob/master/examples/strlen.rs) uses a BPF hashmap to count frequencies of every string that `strlen` is run on. Port of [strlen_count.py](https://github.com/iovisor/bcc/blob/master/examples/tracing/strlen_count.py) to Rust.
-* [examples/opensnoop.rs](https://github.com/rust-bpf/rust-bcc/blob/master/examples/opensnoop.rs) uses perf events to track every time a file is opened on the system. Port of [opensnoop.py](https://github.com/iovisor/bcc/blob/master/examples/tracing/opensnoop.py) to Rust.
+* [examples/opensnoop.rs](https://github.com/rust-bpf/rust-bcc/blob/master/examples/opensnoop.rs) uses perf events to track every time a file is opened on the system. Port of [opensnoop.py](https://github.com/iovisor/bcc/blob/master/tools/opensnoop.py) to Rust.
 * [examples/softirq.rs](https://github.com/rust-bpf/rust-bcc/blob/master/examples/softirqs.rs) uses
   kernel tracepoints to report time spent in softirq handlers. Port of [softirqs.py](https://github.com/iovisor/bcc/blob/master/tools/softirqs.py) to Rust.


### PR DESCRIPTION
Noticed the link on the readme was wrong, correcting it to the current location