### PR TITLE
feature: get_syscall_fnname implementation

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -321,7 +321,6 @@ impl BPF {
         if let Ok(prefix) = self.get_syscall_prefix() {
             return Ok(prefix + name);
         } else {
-            // will never hit this
             return Err(format_err!("error getting syscall fnname: {}", name));
         }
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -310,7 +310,7 @@ impl BPF {
     pub fn get_syscall_prefix(&mut self) -> Result<String, Error> {
         for prefix in SYSCALL_PREFIXES.iter() {
             if self.ksymname(prefix).is_ok() {
-                return Ok(prefix.to_owned().to_string());
+                return Ok((*prefix).to_string());
             }
         }
 
@@ -319,9 +319,9 @@ impl BPF {
 
     pub fn get_syscall_fnname(&mut self, name: &str) -> Result<String, Error> {
         if let Ok(prefix) = self.get_syscall_prefix() {
-            return Ok(prefix + name);
+            Ok(prefix + name)
         } else {
-            return Err(format_err!("error getting syscall fnname: {}", name));
+            Err(format_err!("error getting syscall fnname: {}", name))
         }
     }
 
@@ -442,7 +442,7 @@ impl Drop for BPF {
     }
 }
 
-const SYSCALL_PREFIXES: [&'static str; 7] = [
+const SYSCALL_PREFIXES: [&str; 7] = [
     "sys_",
     "__x64_sys_",
     "__x32_compat_sys_",

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -307,6 +307,25 @@ impl BPF {
         }
     }
 
+    pub fn get_syscall_prefix(&mut self) -> Result<String, Error> {
+        for prefix in SYSCALL_PREFIXES.iter() {
+            if self.ksymname(prefix).is_ok() {
+                return Ok(prefix.to_owned().to_string());
+            }
+        }
+
+        Ok(String::from(*SYSCALL_PREFIXES.first().unwrap()))
+    }
+
+    pub fn get_syscall_fnname(&mut self, name: &str) -> Result<String, Error> {
+        if let Ok(prefix) = self.get_syscall_prefix() {
+            return Ok(prefix + name);
+        } else {
+            // will never hit this
+            return Err(format_err!("error getting syscall fnname: {}", name));
+        }
+    }
+
     pub fn attach_uretprobe(
         &mut self,
         binary_path: &str,
@@ -423,3 +442,13 @@ impl Drop for BPF {
         };
     }
 }
+
+const SYSCALL_PREFIXES: [&'static str; 7] = [
+    "sys_",
+    "__x64_sys_",
+    "__x32_compat_sys_",
+    "__ia32_compat_sys_",
+    "__arm64_sys_",
+    "__s390x_sys_",
+    "__s390_sys_",
+];

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -320,7 +320,7 @@ impl BPF {
     pub fn get_syscall_prefix(&mut self) -> String {
         for prefix in SYSCALL_PREFIXES.iter() {
             if self.ksymname(prefix).is_ok() {
-                return prefix.to_string();
+                return (*prefix).to_string();
             }
         }
 


### PR DESCRIPTION
* what problem are you trying to solve? (or if there's no problem, what's the motivation for this
  change?)
    - ease of getting syscall fn name prefixed by the current system's prefix
* what changes does this pull request make?
    - port `get_syscall_fnname` and `get_syscall_prefix` from python
    - add const array of system prefixs
* are there any non-obvious implications of these changes? (does it break compatibility with previous
  versions, etc)
    - Nope!

This doesn't exactly feel 'rusty' or elegant by any means, so I would *love* feedback on improving it.  It may be worth also implementing ` fix_syscall_fnname` as well since these all work together. Thoughts?

#86 
