### PR TITLE
modernize error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ edition = '2018'
 [dependencies]
 bcc-sys = "0.13.0"
 byteorder = "1.3.4"
-failure = "0.1.7"
 libc = "0.2.68"
 regex = "1.3.5"
+thiserror = "1.0.19"
 
 [dev-dependencies]
 clap = "2.33.0"

--- a/examples/biosnoop.rs
+++ b/examples/biosnoop.rs
@@ -1,7 +1,7 @@
 use bcc::core::BPF;
 use bcc::perf::init_perf_map;
+use bcc::BccError;
 use clap::{App, Arg};
-use failure::Error;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::ptr;
@@ -24,7 +24,7 @@ struct data_t {
     name: [u8; 16],
 }
 
-fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     let matches = App::new("biosnoop")
         .about("Trace block I/O")
         .arg(

--- a/examples/biosnoop.rs
+++ b/examples/biosnoop.rs
@@ -134,7 +134,6 @@ fn main() {
 
     if let Err(x) = do_main(runnable) {
         eprintln!("Error: {}", x);
-        eprintln!("{}", x.backtrace());
         std::process::exit(1);
     }
 }

--- a/examples/opensnoop.rs
+++ b/examples/opensnoop.rs
@@ -5,8 +5,8 @@ extern crate libc;
 
 use bcc::core::BPF;
 use bcc::perf::init_perf_map;
+use bcc::BccError;
 use clap::{App, Arg};
-use failure::Error;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::ptr;
@@ -34,7 +34,7 @@ struct data_t {
     fname: [u8; 255], // NAME_MAX
 }
 
-fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     let matches = App::new("opensnoop")
         .about("Prints out filename + PID every time a file is opened")
         .arg(

--- a/examples/opensnoop.rs
+++ b/examples/opensnoop.rs
@@ -1,8 +1,3 @@
-extern crate bcc;
-extern crate byteorder;
-extern crate failure;
-extern crate libc;
-
 use bcc::core::BPF;
 use bcc::perf::init_perf_map;
 use bcc::BccError;
@@ -112,7 +107,6 @@ fn main() {
     match do_main(runnable) {
         Err(x) => {
             eprintln!("Error: {}", x);
-            eprintln!("{}", x.backtrace());
             std::process::exit(1);
         }
         _ => {}

--- a/examples/runqlat.rs
+++ b/examples/runqlat.rs
@@ -23,7 +23,7 @@ fn attach_events(bpf: &mut BPF) {
         .unwrap();
 }
 
-#[cfg(any(not(feature = "v0_4_0"), not(feature = "v0_5_0"),))]
+#[cfg(not(any(feature = "v0_4_0", feature = "v0_5_0")))]
 fn attach_events(bpf: &mut BPF) {
     if bpf.support_raw_tracepoint() {
         let raw_tp_sched_wakeup = bpf.load_raw_tracepoint("raw_tp__sched_wakeup").unwrap();
@@ -131,7 +131,6 @@ fn main() {
     match do_main(runnable) {
         Err(x) => {
             eprintln!("Error: {}", x);
-            eprintln!("{}", x.backtrace());
             std::process::exit(1);
         }
         _ => {}

--- a/examples/runqlat.rs
+++ b/examples/runqlat.rs
@@ -1,6 +1,6 @@
 use bcc::core::BPF;
+use bcc::BccError;
 use clap::{App, Arg};
-use failure::Error;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -50,7 +50,7 @@ fn attach_events(bpf: &mut BPF) {
     }
 }
 
-fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     let matches = App::new("runqlat")
         .about("Reports distribution of scheduler latency")
         .arg(

--- a/examples/softirqs.rs
+++ b/examples/softirqs.rs
@@ -1,6 +1,7 @@
 use bcc::core::BPF;
+use bcc::BccError;
 use clap::{App, Arg};
-use failure::Error;
+use std::error::Error;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -73,7 +74,7 @@ impl fmt::Display for SoftIRQ {
     }
 }
 
-fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     let matches = App::new("softirqs")
         .about("Reports time spent in IRQ Handlers")
         .arg(

--- a/examples/softirqs.rs
+++ b/examples/softirqs.rs
@@ -170,7 +170,6 @@ fn main() {
     match do_main(runnable) {
         Err(x) => {
             eprintln!("Error: {}", x);
-            eprintln!("{}", x.backtrace());
             std::process::exit(1);
         }
         _ => {}

--- a/examples/strlen.rs
+++ b/examples/strlen.rs
@@ -1,6 +1,5 @@
 extern crate bcc;
 extern crate byteorder;
-extern crate failure;
 extern crate libc;
 
 use bcc::core::BPF;
@@ -75,7 +74,6 @@ fn main() {
     match do_main(runnable) {
         Err(x) => {
             eprintln!("Error: {}", x);
-            eprintln!("{}", x.backtrace());
             std::process::exit(1);
         }
         _ => {}

--- a/examples/strlen.rs
+++ b/examples/strlen.rs
@@ -4,14 +4,14 @@ extern crate failure;
 extern crate libc;
 
 use bcc::core::BPF;
+use bcc::BccError;
 use byteorder::{NativeEndian, ReadBytesExt};
-use failure::Error;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::io::Cursor;
 use std::sync::Arc;
 
-fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     let code = "
 #include <uapi/linux/ptrace.h>
 

--- a/examples/tcpretrans.rs
+++ b/examples/tcpretrans.rs
@@ -1,8 +1,8 @@
 use bcc::core::BPF;
+use bcc::BccError;
 extern crate chrono;
 use chrono::Utc;
 use clap::{App, Arg};
-use failure::Error;
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::net::Ipv4Addr;
@@ -38,7 +38,7 @@ struct ipv6_data_t {
     type_: u64,
 }
 
-fn do_main(runnable: Arc<AtomicBool>) -> Result<(), Error> {
+fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     let matches = App::new("biosnoop")
         .arg(
             Arg::with_name("duration")

--- a/examples/tcpretrans.rs
+++ b/examples/tcpretrans.rs
@@ -1,6 +1,5 @@
 use bcc::core::BPF;
 use bcc::BccError;
-extern crate chrono;
 use chrono::Utc;
 use clap::{App, Arg};
 
@@ -81,7 +80,7 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     Ok(())
 }
 
-fn print_ipv4_event() -> Box<FnMut(&[u8]) + Send> {
+fn print_ipv4_event() -> Box<dyn FnMut(&[u8]) + Send> {
     Box::new(|x| {
         let event = parse_ipv4_struct(x);
         println!(
@@ -97,7 +96,7 @@ fn print_ipv4_event() -> Box<FnMut(&[u8]) + Send> {
     })
 }
 
-fn print_ipv6_event() -> Box<FnMut(&[u8]) + Send> {
+fn print_ipv6_event() -> Box<dyn FnMut(&[u8]) + Send> {
     Box::new(|x| {
         let event = parse_ipv6_struct(x);
         println!(
@@ -131,7 +130,6 @@ fn main() {
 
     if let Err(x) = do_main(runnable) {
         eprintln!("Error: {}", x);
-        eprintln!("{}", x.backtrace());
         std::process::exit(1);
     }
 }

--- a/src/core/kprobe/v0_4_0.rs
+++ b/src/core/kprobe/v0_4_0.rs
@@ -1,10 +1,10 @@
 use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_ENTRY as BPF_PROBE_ENTRY;
 use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_RETURN as BPF_PROBE_RETURN;
 use bcc_sys::bccapi::*;
-use failure::*;
 
 use crate::core::make_alphanumeric;
 use crate::types::MutPointer;
+use crate::BccError;
 
 use regex::Regex;
 
@@ -23,11 +23,9 @@ pub struct Kprobe {
 }
 
 impl Kprobe {
-    fn new(name: &str, attach_type: u32, function: &str, code: File) -> Result<Self, Error> {
-        let cname =
-            CString::new(name).map_err(|_| format_err!("Nul byte in Kprobe name: {}", name))?;
-        let cfunction = CString::new(function)
-            .map_err(|_| format_err!("Nul byte in Kprobe function: {}", function))?;
+    fn new(name: &str, attach_type: u32, function: &str, code: File) -> Result<Self, BccError> {
+        let cname = CString::new(name)?;
+        let cfunction = CString::new(function)?;
         let (pid, cpu, group_fd) = (-1, 0, -1);
         let ptr = unsafe {
             bpf_attach_kprobe(
@@ -43,7 +41,15 @@ impl Kprobe {
             )
         };
         if ptr.is_null() {
-            Err(format_err!("Failed to attach Kprobe: {}", name))
+            match attach_type {
+                BPF_PROBE_ENTRY => Err(BccError::AttachKprobe {
+                    name: name.to_string(),
+                }),
+                BPF_PROBE_RETURN => Err(BccError::AttachKretprobe {
+                    name: name.to_string(),
+                }),
+                _ => unreachable!(),
+            }
         } else {
             Ok(Self {
                 p: ptr,
@@ -53,19 +59,17 @@ impl Kprobe {
         }
     }
 
-    pub fn attach_kprobe(function: &str, code: File) -> Result<Self, Error> {
+    pub fn attach_kprobe(function: &str, code: File) -> Result<Self, BccError> {
         let name = format!("p_{}", &make_alphanumeric(function));
         Kprobe::new(&name, BPF_PROBE_ENTRY, function, code)
-            .map_err(|_| format_err!("Failed to attach Kprobe: {}", name))
     }
 
-    pub fn attach_kretprobe(function: &str, code: File) -> Result<Self, Error> {
+    pub fn attach_kretprobe(function: &str, code: File) -> Result<Self, BccError> {
         let name = format!("r_{}", &make_alphanumeric(function));
         Kprobe::new(&name, BPF_PROBE_RETURN, function, code)
-            .map_err(|_| format_err!("Failed to attach Kretprobe: {}", name))
     }
 
-    pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>, Error> {
+    pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>, BccError> {
         let mut fns: Vec<String> = vec![];
 
         enum Section {
@@ -117,19 +121,18 @@ impl Kprobe {
                 Section::End => (),
             }
             // All functions defined as NOKPROBE_SYMBOL() start with the
-            // prefix _kbl_addr_*, blacklisting them by looking at the name
+            // prefix _kbl_addr_*, excluding them by looking at the name
             // allows to catch also those symbols that are defined in kernel
             // modules.
             if fname.starts_with("_kbl_addr_") {
                 continue;
             }
-            // Explicitly blacklist perf-related functions, they are all
-            // non-attachable.
-            else if fname.starts_with("__perf") || fname.starts_with("perf_") {
+            // Exclude perf-related functions, they are all non-attachable.
+            if fname.starts_with("__perf") || fname.starts_with("perf_") {
                 continue;
             }
             // Exclude all gcc 8's extra .cold functions
-            else if re.is_match(fname) {
+            if re.is_match(fname) {
                 continue;
             }
             if (t == "t" || t == "w") && fname.contains(event_re) {

--- a/src/core/kprobe/v0_6_0.rs
+++ b/src/core/kprobe/v0_6_0.rs
@@ -1,9 +1,9 @@
 use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_ENTRY as BPF_PROBE_ENTRY;
 use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_RETURN as BPF_PROBE_RETURN;
 use bcc_sys::bccapi::*;
-use failure::*;
 
 use crate::core::make_alphanumeric;
+use crate::BccError;
 
 use regex::Regex;
 
@@ -21,11 +21,9 @@ pub struct Kprobe {
 }
 
 impl Kprobe {
-    fn new(name: &str, attach_type: u32, function: &str, code: File) -> Result<Self, Error> {
-        let cname =
-            CString::new(name).map_err(|_| format_err!("Nul byte in Kprobe name: {}", name))?;
-        let cfunction = CString::new(function)
-            .map_err(|_| format_err!("Nul byte in Kprobe function: {}", function))?;
+    fn new(name: &str, attach_type: u32, function: &str, code: File) -> Result<Self, BccError> {
+        let cname = CString::new(name)?;
+        let cfunction = CString::new(function)?;
         let ptr = unsafe {
             bpf_attach_kprobe(
                 code.as_raw_fd(),
@@ -36,7 +34,15 @@ impl Kprobe {
             )
         };
         if ptr < 0 {
-            Err(format_err!("Failed to attach Kprobe: {}", name))
+            match attach_type {
+                BPF_PROBE_ENTRY => Err(BccError::AttachKprobe {
+                    name: name.to_string(),
+                }),
+                BPF_PROBE_RETURN => Err(BccError::AttachKretprobe {
+                    name: name.to_string(),
+                }),
+                _ => unreachable!(),
+            }
         } else {
             Ok(Self {
                 p: ptr,
@@ -46,19 +52,17 @@ impl Kprobe {
         }
     }
 
-    pub fn attach_kprobe(function: &str, code: File) -> Result<Self, Error> {
+    pub fn attach_kprobe(function: &str, code: File) -> Result<Self, BccError> {
         let name = format!("p_{}", &make_alphanumeric(function));
         Kprobe::new(&name, BPF_PROBE_ENTRY, function, code)
-            .map_err(|_| format_err!("Failed to attach Kprobe: {}", name))
     }
 
-    pub fn attach_kretprobe(function: &str, code: File) -> Result<Self, Error> {
+    pub fn attach_kretprobe(function: &str, code: File) -> Result<Self, BccError> {
         let name = format!("r_{}", &make_alphanumeric(function));
         Kprobe::new(&name, BPF_PROBE_RETURN, function, code)
-            .map_err(|_| format_err!("Failed to attach Kretprobe: {}", name))
     }
 
-    pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>, Error> {
+    pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>, BccError> {
         let mut fns: Vec<String> = vec![];
 
         enum Section {
@@ -110,19 +114,18 @@ impl Kprobe {
                 Section::End => (),
             }
             // All functions defined as NOKPROBE_SYMBOL() start with the
-            // prefix _kbl_addr_*, blacklisting them by looking at the name
+            // prefix _kbl_addr_*, excluding them by looking at the name
             // allows to catch also those symbols that are defined in kernel
             // modules.
             if fname.starts_with("_kbl_addr_") {
                 continue;
             }
-            // Explicitly blacklist perf-related functions, they are all
-            // non-attachable.
-            else if fname.starts_with("__perf") || fname.starts_with("perf_") {
+            // Exclude perf-related functions, they are all non-attachable.
+            if fname.starts_with("__perf") || fname.starts_with("perf_") {
                 continue;
             }
             // Exclude all gcc 8's extra .cold functions
-            else if re.is_match(fname) {
+            if re.is_match(fname) {
                 continue;
             }
             if (t == "t" || t == "w") && fname.contains(event_re) {

--- a/src/core/raw_tracepoint/v0_6_0.rs
+++ b/src/core/raw_tracepoint/v0_6_0.rs
@@ -1,5 +1,5 @@
+use crate::BccError;
 use bcc_sys::bccapi::*;
-use failure::*;
 
 use std::ffi::CString;
 use std::fs::File;
@@ -14,12 +14,13 @@ pub struct RawTracepoint {
 }
 
 impl RawTracepoint {
-    pub fn attach_raw_tracepoint(name: &str, file: File) -> Result<Self, Error> {
-        let cname =
-            CString::new(name).map_err(|_| format_err!("Nul byte in Tracepoint name: {}", name))?;
+    pub fn attach_raw_tracepoint(name: &str, file: File) -> Result<Self, BccError> {
+        let cname = CString::new(name)?;
         let ptr = unsafe { bpf_attach_raw_tracepoint(file.as_raw_fd(), cname.as_ptr() as *mut _) };
         if ptr < 0 {
-            Err(format_err!("Failed to attach raw tracepoint: {}", name))
+            Err(BccError::AttachRawTracepoint {
+                name: name.to_string(),
+            })
         } else {
             Ok(Self {
                 name: cname,

--- a/src/core/uprobe/v0_4_0.rs
+++ b/src/core/uprobe/v0_4_0.rs
@@ -1,11 +1,11 @@
 use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_ENTRY as BPF_PROBE_ENTRY;
 use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_RETURN as BPF_PROBE_RETURN;
 use bcc_sys::bccapi::*;
-use failure::*;
 
 use crate::core::make_alphanumeric;
 use crate::symbol;
 use crate::types::MutPointer;
+use crate::BccError;
 
 use std::ffi::CString;
 use std::fs::File;
@@ -28,11 +28,9 @@ impl Uprobe {
         addr: u64,
         file: File,
         pid: pid_t,
-    ) -> Result<Self, Error> {
-        let cname =
-            CString::new(name).map_err(|_| format_err!("Nul byte in Uprobe name: {}", name))?;
-        let cpath =
-            CString::new(path).map_err(|_| format_err!("Nul byte in Uprobe path: {}", name))?;
+    ) -> Result<Self, BccError> {
+        let cname = CString::new(name)?;
+        let cpath = CString::new(path)?;
         // TODO: maybe pass in the CPU & PID instead of
         let (cpu, group_fd) = (0, -1);
         let uprobe_ptr = unsafe {
@@ -50,7 +48,15 @@ impl Uprobe {
             )
         };
         if uprobe_ptr.is_null() {
-            Err(format_err!("Failed to attach Uprobe: {}", name))
+            match attach_type {
+                BPF_PROBE_ENTRY => Err(BccError::AttachUprobe {
+                    name: name.to_string(),
+                }),
+                BPF_PROBE_RETURN => Err(BccError::AttachUretprobe {
+                    name: name.to_string(),
+                }),
+                _ => unreachable!(),
+            }
         } else {
             Ok(Self {
                 code_fd: file,
@@ -65,12 +71,11 @@ impl Uprobe {
         symbol: &str,
         code: File,
         pid: pid_t,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, BccError> {
         let (path, addr) = symbol::resolve_symbol_path(binary_path, symbol, 0x0, pid)?;
         let alpha_path = make_alphanumeric(&path);
         let ev_name = format!("r_{}_0x{:x}", &alpha_path, addr);
         Uprobe::new(&ev_name, BPF_PROBE_ENTRY, &path, addr, code, pid)
-            .map_err(|_| format_err!("Failed to attach Uprobe to binary: {}", binary_path))
     }
 
     pub fn attach_uretprobe(
@@ -78,12 +83,11 @@ impl Uprobe {
         symbol: &str,
         code: File,
         pid: pid_t,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, BccError> {
         let (path, addr) = symbol::resolve_symbol_path(binary_path, symbol, 0x0, pid)?;
         let alpha_path = make_alphanumeric(&path);
         let ev_name = format!("r_{}_0x{:x}", &alpha_path, addr);
         Uprobe::new(&ev_name, BPF_PROBE_RETURN, &path, addr, code, pid)
-            .map_err(|_| format_err!("Failed to attach Uretprobe to binary: {}", binary_path))
     }
 }
 

--- a/src/cpuonline.rs
+++ b/src/cpuonline.rs
@@ -1,4 +1,4 @@
-use failure::*;
+use crate::BccError;
 
 use std::fs::File;
 use std::io::Read;
@@ -7,14 +7,18 @@ use std::str::FromStr;
 const CPUONLINE: &str = "/sys/devices/system/cpu/online";
 
 // loosely based on https://github.com/iovisor/bcc/blob/v0.3.0/src/python/bcc/utils.py#L15
-fn read_cpu_range(cpu_range_str: &str) -> Result<Vec<usize>, Error> {
+fn read_cpu_range(cpu_range_str: &str) -> Result<Vec<usize>, BccError> {
     let mut cpus = Vec::new();
     let cpu_range_str_trim = cpu_range_str.trim();
     for cpu_range in cpu_range_str_trim.split(',') {
         let rangeop: Vec<&str> = cpu_range.splitn(2, '-').collect();
         let first = match usize::from_str(rangeop[0]) {
             Ok(res) => res,
-            Err(e) => return Err(format_err!("Fail to recognize first cpu number: {}", e)),
+            Err(_) => {
+                return Err(BccError::InvalidCpuRange {
+                    range: cpu_range_str.to_string(),
+                })
+            }
         };
         if rangeop.len() == 1 {
             cpus.push(first);
@@ -22,7 +26,11 @@ fn read_cpu_range(cpu_range_str: &str) -> Result<Vec<usize>, Error> {
         }
         let last = match usize::from_str(rangeop[1]) {
             Ok(res) => res,
-            Err(e) => return Err(format_err!("Fail to recognize second cpu number: {}", e)),
+            Err(_) => {
+                return Err(BccError::InvalidCpuRange {
+                    range: cpu_range_str.to_string(),
+                })
+            }
         };
         for n in first..=last {
             cpus.push(n);
@@ -31,7 +39,7 @@ fn read_cpu_range(cpu_range_str: &str) -> Result<Vec<usize>, Error> {
     Ok(cpus)
 }
 
-pub fn get() -> Result<Vec<usize>, Error> {
+pub fn get() -> Result<Vec<usize>, BccError> {
     let mut buffer = String::new();
     File::open(CPUONLINE)?.read_to_string(&mut buffer)?;
     read_cpu_range(&buffer)

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,43 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum BccError {
+    #[error("failed to attach kprobe: ({name})")]
+    AttachKprobe { name: String },
+    #[error("failed to attach kretprobe ({name})")]
+    AttachKretprobe { name: String },
+    #[error("failed to attach raw tracepoint ({name})")]
+    AttachRawTracepoint { name: String },
+    #[error("failed to attach tracepoint ({subsys}:{name})")]
+    AttachTracepoint { subsys: String, name: String },
+    #[error("failed to attach uprobe ({name})")]
+    AttachUprobe { name: String },
+    #[error("failed to attach uretprobe ({name})")]
+    AttachUretprobe { name: String },
+    #[error("error compiling bpf")]
+    Compilation,
+    #[error("io error")]
+    IoError(#[from] std::io::Error),
+    #[error("error initializing perf map")]
+    InitializePerfMap,
+    #[error("invalid cpu range ({range})")]
+    InvalidCpuRange { range: String },
+    #[error("error loading bpf probe ({name})")]
+    Loading { name: String },
+    #[error("null string")]
+    NullString(#[from] std::ffi::NulError),
+    #[error("error opening perf buffer")]
+    OpenPerfBuffer,
+    #[error("failed to delete key from table")]
+    TableDelete,
+    #[error("failed to get value from table")]
+    TableGet,
+    #[error("failed to set value in table")]
+    TableSet,
+    #[error("table has wrong size for key or leaf")]
+    TableSize,
+    #[error("unknown symbol ({name}) in module ({module})")]
+    UnknownSymbol { name: String, module: String },
+    #[error("invalid utf8")]
+    Utf8Error(#[from] std::str::Utf8Error),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,13 +29,13 @@ pub enum BccError {
     #[error("error opening perf buffer")]
     OpenPerfBuffer,
     #[error("failed to delete key from table")]
-    TableDelete,
+    DeleteTableValue,
     #[error("failed to get value from table")]
-    TableGet,
+    GetTableValue,
     #[error("failed to set value in table")]
-    TableSet,
+    SetTableValue,
     #[error("table has wrong size for key or leaf")]
-    TableSize,
+    TableInvalidSize,
     #[error("unknown symbol ({name}) in module ({module})")]
     UnknownSymbol { name: String, module: String },
     #[error("invalid utf8")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,10 @@
 
 pub mod core;
 mod cpuonline;
+mod error;
 pub mod perf;
 pub mod symbol;
 pub mod table;
 mod types;
+
+pub use error::BccError;

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -61,7 +61,7 @@ where
     let leaf = vec![0; leaf_size];
 
     if key_size != 4 || leaf_size != 4 {
-        return Err(BccError::TableSize);
+        return Err(BccError::TableInvalidSize);
     }
 
     let mut readers: Vec<PerfReader> = vec![];

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -1,15 +1,14 @@
 use bcc_sys::bccapi::*;
 use byteorder::{NativeEndian, WriteBytesExt};
-use failure::*;
 
 use core::ffi::c_void;
 use core::sync::atomic::{AtomicPtr, Ordering};
-use std;
 use std::io::Cursor;
 
 use crate::cpuonline;
 use crate::table::Table;
 use crate::types::*;
+use crate::BccError;
 
 struct PerfCallback {
     raw_cb: Box<dyn FnMut(&[u8]) + Send>,
@@ -53,7 +52,7 @@ pub struct PerfMap {
     pub readers: Vec<PerfReader>,
 }
 
-pub fn init_perf_map<F>(mut table: Table, cb: F) -> Result<PerfMap, Error>
+pub fn init_perf_map<F>(mut table: Table, cb: F) -> Result<PerfMap, BccError>
 where
     F: Fn() -> Box<dyn FnMut(&[u8]) + Send>,
 {
@@ -62,7 +61,7 @@ where
     let leaf = vec![0; leaf_size];
 
     if key_size != 4 || leaf_size != 4 {
-        return Err(format_err!("passed table has wrong size"));
+        return Err(BccError::TableSize);
     }
 
     let mut readers: Vec<PerfReader> = vec![];
@@ -77,10 +76,11 @@ where
         let mut key = vec![];
         key.write_u32::<NativeEndian>(*cpu as u32)?;
         cur.write_u32::<NativeEndian>(perf_fd)?;
-        table
-            .set(&mut key, &mut cur.get_mut())
-            .context("Unable to initialize perf map")?;
-        cur.set_position(0);
+        if table.set(&mut key, &mut cur.get_mut()).is_ok() {
+            cur.set_position(0);
+        } else {
+            return Err(BccError::InitializePerfMap);
+        }
     }
     Ok(PerfMap { readers })
 }
@@ -97,7 +97,10 @@ impl PerfMap {
     }
 }
 
-fn open_perf_buffer(cpu: usize, raw_cb: Box<dyn FnMut(&[u8]) + Send>) -> Result<PerfReader, Error> {
+fn open_perf_buffer(
+    cpu: usize,
+    raw_cb: Box<dyn FnMut(&[u8]) + Send>,
+) -> Result<PerfReader, BccError> {
     let callback = Box::new(PerfCallback { raw_cb });
     let reader = unsafe {
         bpf_open_perf_buffer(
@@ -110,7 +113,7 @@ fn open_perf_buffer(cpu: usize, raw_cb: Box<dyn FnMut(&[u8]) + Send>) -> Result<
         )
     };
     if reader.is_null() {
-        return Err(format_err!("failed to open perf buffer"));
+        return Err(BccError::OpenPerfBuffer);
     }
     Ok(PerfReader {
         ptr: AtomicPtr::new(reader as *mut perf_reader),

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -1,5 +1,6 @@
+use crate::BccError;
+
 use bcc_sys::bccapi::*;
-use failure::*;
 use libc::free;
 
 use core::ffi::c_void;
@@ -14,7 +15,7 @@ pub fn resolve_symbol_path(
     symname: &str,
     addr: u64,
     pid: pid_t,
-) -> Result<(String, u64), Error> {
+) -> Result<(String, u64), BccError> {
     let pid: pid_t = match pid {
         -1 => 0,
         x => x,
@@ -28,7 +29,7 @@ pub fn resolve_symname(
     symname: &str,
     addr: u64,
     pid: pid_t,
-) -> Result<(String, u64), Error> {
+) -> Result<(String, u64), BccError> {
     let mut symbol = unsafe { mem::zeroed::<bcc_symbol>() };
     let cmodule = CString::new(module)?;
     let csymname = CString::new(symname)?;
@@ -44,12 +45,10 @@ pub fn resolve_symname(
         )
     };
     if res < 0 {
-        Err(format_err!(
-            "unable to locate symbol {} in module {}: {}",
-            &symname,
-            module,
-            res
-        ))
+        Err(BccError::UnknownSymbol {
+            name: symname.to_string(),
+            module: module.to_string(),
+        })
     } else {
         let module = unsafe {
             CStr::from_ptr(symbol.module as *mut i8)
@@ -75,7 +74,7 @@ impl SymbolCache {
         }
     }
 
-    pub fn resolve_name(&self, module: &str, name: &str) -> Result<u64, Error> {
+    pub fn resolve_name(&self, module: &str, name: &str) -> Result<u64, BccError> {
         let cmodule = CString::new(module)?;
         let cname = CString::new(name)?;
         let mut addr: u64 = 0;
@@ -89,12 +88,10 @@ impl SymbolCache {
             )
         };
         if res < 0 {
-            Err(format_err!(
-                "unable to locate symbol {} in module {}: {}",
-                &name,
-                module,
-                res
-            ))
+            Err(BccError::UnknownSymbol {
+                name: name.to_string(),
+                module: module.to_string(),
+            })
         } else {
             Ok(addr)
         }

--- a/src/table.rs
+++ b/src/table.rs
@@ -41,7 +41,7 @@ impl Table {
         let res = unsafe { bpf_delete_elem(fd, key.as_mut_ptr() as MutPointer) };
         match res {
             0 => Ok(()),
-            _ => Err(Error::TableDelete),
+            _ => Err(BccError::TableDelete),
         }
     }
 
@@ -63,7 +63,7 @@ impl Table {
         };
         match res {
             0 => Ok(leaf),
-            _ => Err(Error::TableGet),
+            _ => Err(BccError::TableGet),
         }
     }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -41,7 +41,7 @@ impl Table {
         let res = unsafe { bpf_delete_elem(fd, key.as_mut_ptr() as MutPointer) };
         match res {
             0 => Ok(()),
-            _ => Err(BccError::TableDelete),
+            _ => Err(BccError::DeleteTableValue),
         }
     }
 
@@ -63,7 +63,7 @@ impl Table {
         };
         match res {
             0 => Ok(leaf),
-            _ => Err(BccError::TableGet),
+            _ => Err(BccError::GetTableValue),
         }
     }
 
@@ -79,7 +79,7 @@ impl Table {
         // TODO: maybe we can get an errno here to enhance the error message with?
         match res {
             0 => Ok(()),
-            _ => Err(BccError::TableSet),
+            _ => Err(BccError::SetTableValue),
         }
     }
 


### PR DESCRIPTION
Problem

Currently, we do error handling with the `failure` crate which
requires that users are aware of `failure` and use it in their
library or application.

Solution

Switch error handling to use the `thiserror` crate which allows us
to derive `std::error::Error` for our error type.

Result

This library's public API now uses `std::error::Error` in the
`Result`s. This allows better composition within higher level
libraries and applications.

This will be a breaking change to the existing API.

Notes to reviewers

Some of the `Error` variants might need better naming / error messages, we should try to get naming correct on this pass to avoid additional breaking changes.

Particular areas to focus on:
* should we make order of words within the variant consistent? "AttachKprobe" vs "TableDelete" has the verb and noun in opposite orders, but seems natural?
* if we go with natural sounding variants, do the ones listed make sense?
* tense "Attach" vs "Loading"
* do we capture enough context for each error?

This PR would replace #81 - my understanding is that `anyhow` would be appropriate for an application, but we should use `thiserror` within libraries.

Came across this post, which inspired me to convert to `thiserror`:
https://nick.groenen.me/posts/rust-error-handling/ 