### PR TITLE
fix static linking

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -1,0 +1,309 @@
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bionic-bcc_v0_10_0:
+    name: bionic / bcc 0.10.0
+    runs-on: ubuntu-18.04
+    env:
+      FEATURES: v0_10_0
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      env:
+        cache-name: bionic_nightly_bcc-0.10.0
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}
+    - name: add repo
+      run: echo "deb [trusted=yes] https://repo.iovisor.org/apt/bionic bionic main" | sudo tee /etc/apt/sources.list.d/iovisor.list
+    - name: apt update
+      run: sudo apt-get update
+    - name: install bcc
+      run: sudo apt-get install bcc-tools libbcc
+    - name: test
+      run: bash build/ci.sh
+  xenial-bcc_v0_10_0:
+    name: xenial / bcc 0.10.0
+    runs-on: ubuntu-16.04
+    env:
+      FEATURES: v0_10_0
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      env:
+        cache-name: xenial_nightly_bcc-0.10.0
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}
+    - name: add repo
+      run: echo "deb [trusted=yes] https://repo.iovisor.org/apt/xenial xenial main" | sudo tee /etc/apt/sources.list.d/iovisor.list
+    - name: apt update
+      run: sudo apt-get update
+    - name: install bcc
+      run: sudo apt-get install bcc-tools libbcc
+    - name: test
+      run: bash build/ci.sh
+  xenial-bcc_v0_15_0-static:
+    name: xenial / llvm 8 / bcc 0.15.0 / static
+    runs-on: ubuntu-16.04
+    env:
+      CFLAGS: -fPIC
+      RUSTFLAGS: -L /usr/lib -L /usr/lib64 -L /usr/lib/llvm-8/lib
+      FEATURES: v0_15_0 static llvm_8
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      env:
+        cache-name: xenial_nightly_bcc-0.15.0_static
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+    - name: remove unused packages
+      run: sudo apt-get remove *llvm* *clang*
+    - name: install build deps
+      run: sudo apt-get install clang-8 libclang-8-dev libfl-dev llvm-8-dev llvm-8
+    - name: fetch binutils
+      run: curl -L -O ftp://sourceware.org/pub/binutils/snapshots/binutils-2.34.90.tar.xz
+    - name: build binutils
+      run: tar xf binutils-2.34.90.tar.xz && cd binutils-2.34.90 && ./configure --prefix=/usr && make -j2 && sudo make install
+    - name: fetch zlib
+      run: curl -L -O https://zlib.net/zlib-1.2.11.tar.gz
+    - name: build zlib
+      run: tar xzf zlib-1.2.11.tar.gz && cd zlib-1.2.11 && ./configure --prefix=/usr && make -j2 && sudo make install
+    - name: fetch xz
+      run: curl -L -O https://tukaani.org/xz/xz-5.2.5.tar.gz
+    - name: build xz
+      run: tar xzf xz-5.2.5.tar.gz && cd xz-5.2.5 && ./configure --prefix=/usr && make -j2 && sudo make install
+    - name: fetch ncurses
+      run: curl -L -O ftp://ftp.invisible-island.net/ncurses/ncurses-6.2.tar.gz
+    - name: build ncurses
+      run: tar xzf ncurses-6.2.tar.gz && cd ncurses-6.2 && ./configure --prefix=/usr --with-termlib && make -j2 && sudo make install
+    - name: clone libxml2
+      run: git clone https://gitlab.gnome.org/GNOME/libxml2 && cd libxml2 && git checkout 41a34e1f4ffae2ce401600dbb5fe43f8fe402641
+    - name: build libxml2
+      run: cd libxml2 && autoreconf -fvi && ./configure --prefix=/usr --without-python && make -j2 && sudo make install
+    - name: fetch elfutils
+      run: curl -L -O ftp://sourceware.org/pub/elfutils/0.180/elfutils-0.180.tar.bz2
+    - name: build elfutils
+      run: tar xjf elfutils-0.180.tar.bz2 && cd elfutils-0.180 && ./configure --prefix=/usr --disable-debuginfod && make -j2 && sudo make install
+    - name: clone bcc
+      run: git clone https://github.com/iovisor/bcc
+    - name: checkout version
+      run: cd bcc && git checkout e41f7a3be5c8114ef6a0990e50c2fbabea0e928e
+    - name: build and install bcc
+      run: mkdir bcc/_build && cd bcc/_build && cmake .. -DCMAKE_INSTALL_PREFIX=/usr && make -j2 && sudo make install && find . -name "*.a" -exec sudo cp -v {} /usr/lib/ \;
+    - name: test
+      run: bash build/ci.sh
+  focal-bcc_v0_12_0:
+    name: focal / llvm 9 / bcc 0.12.0
+    runs-on: ubuntu-20.04
+    env:
+      FEATURES: v0_12_0
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      env:
+        cache-name: focal_nightly_bcc-0.12.0
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}
+    - name: remove unused packages
+      run: sudo apt-get remove *llvm-6.0* *clang-6.0*
+    - name: install build deps
+      run: sudo apt-get install libelf-dev libclang-9-dev libfl-dev
+    - name: clone bcc
+      run: git clone https://github.com/iovisor/bcc
+    - name: checkout version
+      run: cd bcc && git checkout 368a5b0714961953f3e3f61607fa16cb71449c1b
+    - name: build and install bcc
+      run: mkdir bcc/_build && cd bcc/_build && cmake .. -DCMAKE_INSTALL_PREFIX=/usr && make -j2 && sudo make install
+    - name: test
+      run: bash build/ci.sh
+  focal-bcc_v0_13_0:
+    name: focal / llvm 9 / bcc 0.13.0
+    runs-on: ubuntu-20.04
+    env:
+      FEATURES: v0_13_0
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      env:
+        cache-name: focal_nightly_bcc-0.13.0
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}
+    - name: remove unused packages
+      run: sudo apt-get remove *llvm-6.0* *clang-6.0*
+    - name: install build deps
+      run: sudo apt-get install libelf-dev libclang-9-dev libfl-dev
+    - name: clone bcc
+      run: git clone https://github.com/iovisor/bcc
+    - name: checkout version
+      run: cd bcc && git checkout 942227484d3207f6a42103674001ef01fb5335a0
+    - name: build and install bcc
+      run: mkdir bcc/_build && cd bcc/_build && cmake .. -DCMAKE_INSTALL_PREFIX=/usr && make -j2 && sudo make install
+    - name: test
+      run: bash build/ci.sh
+  focal-bcc_v0_14_0:
+    name: focal / llvm 9 / bcc 0.14.0
+    runs-on: ubuntu-20.04
+    env:
+      FEATURES: v0_14_0
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      env:
+        cache-name: focal_nightly_bcc-0.14.0
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}
+    - name: remove unused packages
+      run: sudo apt-get remove *llvm-6.0* *clang-6.0*
+    - name: install build deps
+      run: sudo apt-get install libelf-dev libclang-9-dev libfl-dev
+    - name: clone bcc
+      run: git clone https://github.com/iovisor/bcc
+    - name: checkout version
+      run: cd bcc && git checkout ceb458d6a07a42d8d6d3c16a3b8e387b5131d610
+    - name: build and install bcc
+      run: mkdir bcc/_build && cd bcc/_build && cmake .. -DCMAKE_INSTALL_PREFIX=/usr && make -j2 && sudo make install
+    - name: test
+      run: bash build/ci.sh
+  focal-bcc_v0_15_0:
+    name: focal / llvm 9 / bcc 0.15.0
+    runs-on: ubuntu-20.04
+    env:
+      FEATURES: v0_15_0
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      env:
+        cache-name: focal_nightly_bcc-0.15.0
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}
+    - name: remove unused packages
+      run: sudo apt-get remove *llvm-6.0* *clang-6.0*
+    - name: install build deps
+      run: sudo apt-get install libelf-dev libclang-9-dev libfl-dev
+    - name: clone bcc
+      run: git clone https://github.com/iovisor/bcc
+    - name: checkout version
+      run: cd bcc && git checkout e41f7a3be5c8114ef6a0990e50c2fbabea0e928e
+    - name: build and install bcc
+      run: mkdir bcc/_build && cd bcc/_build && cmake .. -DCMAKE_INSTALL_PREFIX=/usr && make -j2 && sudo make install
+    - name: test
+      run: bash build/ci.sh
+  focal-bcc_v0_15_0-static:
+    name: focal / llvm 9 / bcc 0.15.0 / static
+    runs-on: ubuntu-20.04
+    env:
+      FEATURES: v0_15_0 static
+    env:
+      CFLAGS: -fPIC
+      RUSTFLAGS: -L /usr/lib -L /usr/lib64 -L /usr/lib/llvm-9/lib
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      env:
+        cache-name: focal_nightly_bcc-0.15.0_static
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+    - name: remove unused packages
+      run: sudo apt-get remove *llvm-6.0* *clang-6.0* *llvm-10* *clang-10*
+    - name: install build deps
+      run: sudo apt-get install libelf-dev libclang-9-dev libfl-dev libxml2-dev llvm-9-dev
+    - name: fetch zlib
+      run: curl -L -O https://zlib.net/zlib-1.2.11.tar.gz
+    - name: build zlib
+      run: tar xzf zlib-1.2.11.tar.gz && cd zlib-1.2.11 && ./configure --prefix=/usr && make -j2 && sudo make install
+    - name: fetch xz
+      run: curl -L -O https://tukaani.org/xz/xz-5.2.5.tar.gz
+    - name: build xz
+      run: tar xzf xz-5.2.5.tar.gz && cd xz-5.2.5 && ./configure --prefix=/usr && make -j2 && sudo make install
+    - name: fetch ncurses
+      run: curl -L -O ftp://ftp.invisible-island.net/ncurses/ncurses-6.2.tar.gz
+    - name: build ncurses
+      run: tar xzf ncurses-6.2.tar.gz && cd ncurses-6.2 && ./configure --prefix=/usr --with-termlib && make -j2 && sudo make install
+    - name: clone libxml2
+      run: git clone https://gitlab.gnome.org/GNOME/libxml2 && cd libxml2 && git checkout 41a34e1f4ffae2ce401600dbb5fe43f8fe402641
+    - name: build libxml2
+      run: cd libxml2 && autoreconf -fvi && ./configure --prefix=/usr --without-python && make -j2 && sudo make install
+    - name: fetch elfutils
+      run: curl -L -O ftp://sourceware.org/pub/elfutils/0.180/elfutils-0.180.tar.bz2
+    - name: build elfutils
+      run: tar xjf elfutils-0.180.tar.bz2 && cd elfutils-0.180 && ./configure --prefix=/usr --disable-debuginfod && make -j2 && sudo make install
+    - name: clone bcc
+      run: git clone https://github.com/iovisor/bcc
+    - name: checkout version
+      run: cd bcc && git checkout e41f7a3be5c8114ef6a0990e50c2fbabea0e928e
+    - name: build and install bcc
+      run: mkdir bcc/_build && cd bcc/_build && cmake .. -DCMAKE_INSTALL_PREFIX=/usr && make -j2 && sudo make install && find . -name "*.a" -exec sudo cp -v {} /usr/lib/ \;
+    - name: test
+      run: bash build/ci.sh
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      env:
+        cache-name: rustfmt
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}
+    - name: install rustfmt
+      run: rustup component add rustfmt
+    - name: rustfmt
+      run: cargo fmt -- --check
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      env:
+        cache-name: clippy
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}
+    - name: install clippy
+      run: rustup component add clippy
+    - name: clippy
+      run: cargo clippy || cargo clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/rust-bpf/rust-bcc"
 edition = '2018'
 
 [dependencies]
-bcc-sys = "0.15.0"
+bcc-sys = "0.15.1"
 byteorder = "1.3.4"
 libc = "0.2.68"
 regex = "1.3.5"
@@ -25,6 +25,8 @@ lazy_static = "1.4.0"
 chrono = "0.4.11"
 
 [features]
+llvm_8 = ["bcc-sys/llvm_8"]
+llvm_9 = ["bcc-sys/llvm_9"]
 static = ["bcc-sys/static"]
 specific = []
 v0_4_0 = ["bcc-sys/v0_4_0", "specific"]

--- a/build/ci.sh
+++ b/build/ci.sh
@@ -1,9 +1,11 @@
 #!/bin/bash -ev
 
 ## Add LLVM repo
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-echo "deb http://apt.llvm.org/${TRAVIS_DIST}/ llvm-toolchain-${TRAVIS_DIST}-${LLVM_VERSION} main" | sudo tee -a /etc/apt/sources.list
-sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
+if [ -n "${TRAVIS_DIST}" ]; then
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+    echo "deb http://apt.llvm.org/${TRAVIS_DIST}/ llvm-toolchain-${TRAVIS_DIST}-${LLVM_VERSION} main" | sudo tee -a /etc/apt/sources.list
+    sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
+fi
 
 ## Update apt
 sudo apt-get update


### PR DESCRIPTION
Update bcc-sys crate to latest version to pickup fixes there.

Adds llvm version feature flags to pass-down to bcc-sys.

Adds static linking tests to ci via GitHub workflows.
