### PR TITLE
prepare for release 0.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # [Unreleased]
 
+# [0.0.21] - 2020-07-24
+## Fixed
+- Iterating on an empty table would improperly return an entry (#100)
+- Fixed some issues with static linking by pulling in a newer version of bcc-sys
+
+## Changed
+- LLVM 9 is now the default expected toolchain for static builds
+
 # [0.0.20] - 2020-07-06
 ## Added
 - Added support for bcc 0.15.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bcc"
-version = "0.0.21-alpha.0"
+version = "0.0.21"
 authors = ["Julia Evans <julia@jvns.ca>", "Brian Martin <bmartin@twitter.com>"]
 description = "Idiomatic Rust bindings for BPF Compiler Collection (BCC)"
 keywords = ["bpf", "bindings", "bcc"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ particularly idiomatic for Rust. Pull requests very much appreciated.
 
 * bcc v0.4.0-v0.15.0
 
+## Static linking
+
+This crate allows for statically linking libbpf/libbcc which enables the creation of tools which
+have no runtime dependency on matching versions being present on target systems. To statically link,
+you may need to compile several dependencies from source. See the `build/ci.sh` script for how those
+dependencies are built and how we build and run statically linked examples in CI.
+
 ## Getting Started
 
 The best way to learn about how to use this crate right now is to read the examples. The exciting


### PR DESCRIPTION
Increment version number for release and update changelog.

Adds notes about static linking to the readme.
