### PR TITLE
added a builder-style pattern for attaching perf events

### DIFF
--- a/examples/contextswitch.rs
+++ b/examples/contextswitch.rs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use bcc::core::BPF;
-use bcc::perf::{EventType, SoftwareEvent};
+use bcc::core::{PerfEventBuilder, BPF};
+use bcc::perf::{Event, SoftwareEvent};
 use bcc::BccError;
 use clap::{App, Arg};
 
@@ -95,16 +95,12 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     }
 
     let mut bpf = BPF::new(&code)?;
-    bpf.attach_perf_event(
-        "do_count",
-        EventType::Software as u32,
-        SoftwareEvent::ContextSwitches as u32,
-        sample_period,
-        sample_frequency,
-        None,
-        None,
-        None,
-    )?;
+    PerfEventBuilder::new()
+        .name("do_count")
+        .event(Event::Software(SoftwareEvent::ContextSwitches))
+        .sample_period(sample_period)
+        .sample_freq(sample_frequency)
+        .attach(&mut bpf)?;
 
     println!("Running for {} seconds", duration);
 

--- a/examples/contextswitch.rs
+++ b/examples/contextswitch.rs
@@ -99,7 +99,7 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
         .name("do_count")
         .event(Event::Software(SoftwareEvent::ContextSwitches))
         .sample_period(sample_period)
-        .sample_freq(sample_frequency)
+        .sample_frequency(sample_frequency)
         .attach(&mut bpf)?;
 
     println!("Running for {} seconds", duration);

--- a/examples/contextswitch.rs
+++ b/examples/contextswitch.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-use bcc::core::{PerfEventBuilder, BPF};
+use bcc::core::{PerfEventProbe, BPF};
 use bcc::perf::{Event, SoftwareEvent};
 use bcc::BccError;
 use clap::{App, Arg};
@@ -95,7 +95,7 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     }
 
     let mut bpf = BPF::new(&code)?;
-    PerfEventBuilder::new()
+    PerfEventProbe::new()
         .name("do_count")
         .event(Event::Software(SoftwareEvent::ContextSwitches))
         .sample_period(sample_period)

--- a/examples/llcstat.rs
+++ b/examples/llcstat.rs
@@ -1,4 +1,4 @@
-use bcc::core::{BPF, PerfEventProbe};
+use bcc::core::{PerfEventProbe, BPF};
 use bcc::perf::{Event, HardwareEvent};
 use bcc::BccError;
 use clap::{App, Arg};

--- a/examples/llcstat.rs
+++ b/examples/llcstat.rs
@@ -1,5 +1,5 @@
-use bcc::core::BPF;
-use bcc::perf::{EventType, HardwareEvent};
+use bcc::core::{BPF, PerfEventProbe};
+use bcc::perf::{Event, HardwareEvent};
 use bcc::BccError;
 use clap::{App, Arg};
 
@@ -52,26 +52,16 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
 
     let code = include_str!("llcstat.c").to_string();
     let mut bpf = BPF::new(&code)?;
-    bpf.attach_perf_event(
-        "on_cache_miss",
-        EventType::Hardware as u32,
-        HardwareEvent::CacheMisses as u32,
-        Some(sample_period),
-        None,
-        None,
-        None,
-        None,
-    )?;
-    bpf.attach_perf_event(
-        "on_cache_ref",
-        EventType::Hardware as u32,
-        HardwareEvent::CacheReferences as u32,
-        Some(sample_period),
-        None,
-        None,
-        None,
-        None,
-    )?;
+    PerfEventProbe::new()
+        .name("on_cache_miss")
+        .event(Event::Hardware(HardwareEvent::CacheMisses))
+        .sample_period(Some(sample_period))
+        .attach(&mut bpf)?;
+    PerfEventProbe::new()
+        .name("on_cache_ref")
+        .event(Event::Hardware(HardwareEvent::CacheReferences))
+        .sample_period(Some(sample_period))
+        .attach(&mut bpf)?;
 
     println!("Running for {} seconds", duration);
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,6 +5,7 @@ mod tracepoint;
 mod uprobe;
 
 pub use crate::core::perf_event::PerfEventProbe;
+
 use bcc_sys::bccapi::*;
 
 use self::kprobe::Kprobe;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -179,10 +179,6 @@ impl BPF {
         self.load(name, bpf_prog_type_BPF_PROG_TYPE_TRACEPOINT, 0, 0)
     }
 
-    pub fn load_perf_event(&mut self, name: &str) -> Result<File, BccError> {
-        self.load(name, bpf_prog_type_BPF_PROG_TYPE_PERF_EVENT, 0, 0)
-    }
-
     #[cfg(any(
         feature = "v0_6_0",
         feature = "v0_6_1",

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,7 +4,7 @@ mod raw_tracepoint;
 mod tracepoint;
 mod uprobe;
 
-pub use crate::core::perf_event::PerfEventBuilder;
+pub use crate::core::perf_event::PerfEventProbe;
 use bcc_sys::bccapi::*;
 
 use self::kprobe::Kprobe;
@@ -386,46 +386,6 @@ impl BPF {
 
     pub fn get_kprobe_functions(&mut self, event_re: &str) -> Result<Vec<String>, BccError> {
         Kprobe::get_kprobe_functions(event_re)
-    }
-
-    pub fn attach_perf_event_builder(
-        &mut self,
-        perf_event_builder: PerfEventBuilder,
-    ) -> Result<(), BccError> {
-        perf_event_builder.attach(self)
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn attach_perf_event(
-        &mut self,
-        name: &str,
-        perf_type: u32,
-        perf_config: u32,
-        sample_period: Option<u64>,
-        sample_freq: Option<u64>,
-        pid: Option<i32>,
-        cpu: Option<usize>,
-        group_fd: Option<i32>,
-    ) -> Result<(), BccError> {
-        let func = self.load(name, bpf_prog_type_BPF_PROG_TYPE_PERF_EVENT, 0, 0);
-
-        match func {
-            Err(e) => Err(e),
-            Ok(f) => {
-                let perf_event = PerfEvent::attach_perf_event(
-                    f,
-                    perf_type,
-                    perf_config,
-                    sample_period,
-                    sample_freq,
-                    pid,
-                    cpu,
-                    group_fd,
-                )?;
-                self.perf_events.insert(perf_event);
-                Ok(())
-            }
-        }
     }
 
     pub fn attach_uprobe(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,6 +4,7 @@ mod raw_tracepoint;
 mod tracepoint;
 mod uprobe;
 
+pub use crate::core::perf_event::PerfEventBuilder;
 use bcc_sys::bccapi::*;
 
 use self::kprobe::Kprobe;
@@ -176,6 +177,10 @@ impl BPF {
 
     pub fn load_tracepoint(&mut self, name: &str) -> Result<File, BccError> {
         self.load(name, bpf_prog_type_BPF_PROG_TYPE_TRACEPOINT, 0, 0)
+    }
+
+    pub fn load_perf_event(&mut self, name: &str) -> Result<File, BccError> {
+        self.load(name, bpf_prog_type_BPF_PROG_TYPE_PERF_EVENT, 0, 0)
     }
 
     #[cfg(any(
@@ -381,6 +386,13 @@ impl BPF {
 
     pub fn get_kprobe_functions(&mut self, event_re: &str) -> Result<Vec<String>, BccError> {
         Kprobe::get_kprobe_functions(event_re)
+    }
+
+    pub fn attach_perf_event_builder(
+        &mut self,
+        perf_event_builder: PerfEventBuilder,
+    ) -> Result<(), BccError> {
+        perf_event_builder.attach(self)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/core/perf_event/mod.rs
+++ b/src/core/perf_event/mod.rs
@@ -13,52 +13,79 @@ pub struct PerfEventProbe {
     name: Option<String>,
     event: Option<Event>,
     sample_period: Option<u64>,
-    sample_freq: Option<u64>,
+    sample_frequency: Option<u64>,
     pid: Option<i32>,
     cpu: Option<usize>,
     group_fd: Option<i32>,
 }
 
+/// A `PerfEventProbe` is used to configure a BPF probe which instruments a
+/// PerfEvent such as a hardware or software event. This structure must be
+/// attached to the `BPF` structure to be useful.
 impl PerfEventProbe {
+	/// Creates a new `PerfEventProbe` with the defaults. You must initialize
+	/// both `name` and `event` fields with the corresponding methods before you
+	/// can `attach` the probe.
     pub fn new() -> Self {
         Default::default()
     }
 
+    /// This corresponds to the function name in the BPF code which will be
+    /// called when the probe fires.
     pub fn name(mut self, name: &str) -> Self {
         self.name = Some(name.to_owned());
         self
     }
 
+    /// The `Event` which will cause a probe to fire, such as a hardware or
+    /// software event.
     pub fn event(mut self, event: Event) -> Self {
         self.event = Some(event);
         self
     }
 
-    pub fn sample_period(mut self, sample_period: Option<u64>) -> Self {
-        self.sample_period = sample_period;
+    /// Specifies that the probe should fire after `count` number of events have
+    /// been counted.
+    pub fn sample_period(mut self, count: Option<u64>) -> Self {
+        self.sample_period = count;
         self
     }
 
-    pub fn sample_freq(mut self, sample_freq: Option<u64>) -> Self {
-        self.sample_freq = sample_freq;
+    /// Causes the probe to run with a frequency specified in hertz (hz)
+    /// equivalent to the number of sampling events per second.
+    pub fn sample_frequency(mut self, hz: Option<u64>) -> Self {
+        self.sample_frequency = hz;
         self
     }
 
+    /// Restrict the scope of the probe to only a given process and its
+    /// children. If this is set to `None` (the default), the probe will cover
+    /// all processes on the system.
     pub fn pid(mut self, pid: Option<i32>) -> Self {
         self.pid = pid;
         self
     }
 
+    /// Restrict the probe to only the given hardware thread. If this is set to
+    /// `None` (the default), a probe will be created for each hardware thread
+    /// on the system to provide system-wide coverage.
     pub fn cpu(mut self, cpu: Option<usize>) -> Self {
         self.cpu = cpu;
         self
     }
 
+    /// This option groups sets of probes together. This will cause the
+    /// multiplexing algorithm in the kernel to group the probes to be running
+    /// on PMUs concurrently. Useful for grouping related probes to maintain
+    /// accurate derived metrics. One example would be to schedule cycle and
+    /// retired instruction probes together to calculate CPI.
     pub fn group_fd(mut self, group_fd: Option<i32>) -> Self {
         self.group_fd = group_fd;
         self
     }
 
+    /// Consumes the probe and attaches it to the `BPF` struct. May return an
+    /// error if there is an underlying failure when attaching the probe.
     pub fn attach(self, bpf: &mut BPF) -> Result<(), BccError> {
         if self.event.is_none() {
             return Err(BccError::IncompletePerfEventProbe {
@@ -93,7 +120,7 @@ impl PerfEventProbe {
             ev_type,
             ev_config,
             self.sample_period.unwrap_or(0),
-            self.sample_freq.unwrap_or(0),
+            self.sample_frequency.unwrap_or(0),
             self.pid.unwrap_or(-1),
             self.cpu,
             self.group_fd.unwrap_or(-1),

--- a/src/core/perf_event/mod.rs
+++ b/src/core/perf_event/mod.rs
@@ -6,6 +6,8 @@ use crate::core::BPF;
 use crate::error::BccError;
 use crate::perf::{Event, EventType};
 
+use bcc_sys::bccapi::bpf_prog_type_BPF_PROG_TYPE_PERF_EVENT;
+
 #[derive(Default)]
 pub struct PerfEventProbe {
     name: Option<String>,
@@ -59,19 +61,19 @@ impl PerfEventProbe {
 
     pub fn attach(self, bpf: &mut BPF) -> Result<(), BccError> {
         if self.event.is_none() {
-            return Err(BccError::IncompletePerfEventBuilder {
+            return Err(BccError::IncompletePerfEventProbe {
                 field: "event".to_string(),
             });
         }
         if self.name.is_none() {
-            return Err(BccError::IncompletePerfEventBuilder {
+            return Err(BccError::IncompletePerfEventProbe {
                 field: "name".to_string(),
             });
         }
         let name = self.name.unwrap();
         let event = self.event.unwrap();
 
-        let code_fd = bpf.load_perf_event(&name)?;
+        let code_fd = bpf.load(&name, bpf_prog_type_BPF_PROG_TYPE_PERF_EVENT, 0, 0)?;
 
         let ev_type = match event {
             Event::Hardware(_) => EventType::Hardware,

--- a/src/core/perf_event/mod.rs
+++ b/src/core/perf_event/mod.rs
@@ -2,8 +2,8 @@ mod v0_4_0;
 
 pub use v0_4_0::*;
 
-use crate::error::BccError;
 use crate::core::BPF;
+use crate::error::BccError;
 use crate::perf::{Event, EventType};
 
 #[derive(Default)]

--- a/src/core/perf_event/mod.rs
+++ b/src/core/perf_event/mod.rs
@@ -23,9 +23,9 @@ pub struct PerfEventProbe {
 /// PerfEvent such as a hardware or software event. This structure must be
 /// attached to the `BPF` structure to be useful.
 impl PerfEventProbe {
-	/// Creates a new `PerfEventProbe` with the defaults. You must initialize
-	/// both `name` and `event` fields with the corresponding methods before you
-	/// can `attach` the probe.
+    /// Creates a new `PerfEventProbe` with the defaults. You must initialize
+    /// both `name` and `event` fields with the corresponding methods before you
+    /// can `attach` the probe.
     pub fn new() -> Self {
         Default::default()
     }
@@ -124,7 +124,8 @@ impl PerfEventProbe {
             self.pid.unwrap_or(-1),
             self.cpu,
             self.group_fd.unwrap_or(-1),
-        ).map_err(|_| BccError::AttachPerfEvent{ event: event })?;
+        )
+        .map_err(|_| BccError::AttachPerfEvent { event })?;
         bpf.perf_events.insert(perf_event);
         Ok(())
     }

--- a/src/core/perf_event/mod.rs
+++ b/src/core/perf_event/mod.rs
@@ -97,7 +97,7 @@ impl PerfEventProbe {
             self.pid.unwrap_or(-1),
             self.cpu,
             self.group_fd.unwrap_or(-1),
-        )?;
+        ).map_err(|_| BccError::AttachPerfEvent{ event: event })?;
         bpf.perf_events.insert(perf_event);
         Ok(())
     }

--- a/src/core/perf_event/mod.rs
+++ b/src/core/perf_event/mod.rs
@@ -1,3 +1,102 @@
 mod v0_4_0;
 
 pub use v0_4_0::*;
+
+use crate::error::BccError;
+use crate::core::BPF;
+use crate::perf::{Event, EventType};
+
+#[derive(Default)]
+pub struct PerfEventProbe {
+    name: Option<String>,
+    event: Option<Event>,
+    sample_period: Option<u64>,
+    sample_freq: Option<u64>,
+    pid: Option<i32>,
+    cpu: Option<usize>,
+    group_fd: Option<i32>,
+}
+
+impl PerfEventProbe {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn name(mut self, name: &str) -> Self {
+        self.name = Some(name.to_owned());
+        self
+    }
+
+    pub fn event(mut self, event: Event) -> Self {
+        self.event = Some(event);
+        self
+    }
+
+    pub fn sample_period(mut self, sample_period: Option<u64>) -> Self {
+        self.sample_period = sample_period;
+        self
+    }
+
+    pub fn sample_freq(mut self, sample_freq: Option<u64>) -> Self {
+        self.sample_freq = sample_freq;
+        self
+    }
+
+    pub fn pid(mut self, pid: Option<i32>) -> Self {
+        self.pid = pid;
+        self
+    }
+
+    pub fn cpu(mut self, cpu: Option<usize>) -> Self {
+        self.cpu = cpu;
+        self
+    }
+
+    pub fn group_fd(mut self, group_fd: Option<i32>) -> Self {
+        self.group_fd = group_fd;
+        self
+    }
+
+    pub fn attach(self, bpf: &mut BPF) -> Result<(), BccError> {
+        if self.event.is_none() {
+            return Err(BccError::IncompletePerfEventBuilder {
+                field: "event".to_string(),
+            });
+        }
+        if self.name.is_none() {
+            return Err(BccError::IncompletePerfEventBuilder {
+                field: "name".to_string(),
+            });
+        }
+        let name = self.name.unwrap();
+        let event = self.event.unwrap();
+
+        let code_fd = bpf.load_perf_event(&name)?;
+
+        let ev_type = match event {
+            Event::Hardware(_) => EventType::Hardware,
+            Event::Software(_) => EventType::Software,
+            Event::HardwareCache(_, _, _) => EventType::HardwareCache,
+        } as u32;
+
+        let ev_config = match event {
+            Event::Hardware(hw_event) => hw_event as u32,
+            Event::Software(sw_event) => sw_event as u32,
+            Event::HardwareCache(id, op, result) => {
+                ((result as u32) << 16) | ((op as u32) << 8) | (id as u32)
+            }
+        };
+        let perf_event = PerfEvent::new(
+            code_fd,
+            ev_type,
+            ev_config,
+            self.sample_period.unwrap_or(0),
+            self.sample_freq.unwrap_or(0),
+            self.pid.unwrap_or(-1),
+            self.cpu,
+            self.group_fd.unwrap_or(-1),
+        )?;
+        bpf.perf_events.insert(perf_event);
+        Ok(())
+    }
+}

--- a/src/core/perf_event/v0_4_0.rs
+++ b/src/core/perf_event/v0_4_0.rs
@@ -1,5 +1,4 @@
 use crate::cpuonline;
-use crate::BccError;
 
 use bcc_sys::bccapi::*;
 
@@ -26,7 +25,7 @@ impl PerfEvent {
         pid: i32,
         cpu: Option<usize>,
         group_fd: i32,
-    ) -> Result<Self, BccError> {
+    ) -> Result<Self, ()> {
         let vec: Vec<i32> = vec![];
 
         if let Some(cpu) = cpu {
@@ -44,7 +43,7 @@ impl PerfEvent {
             };
 
             if ptr < 0 {
-                return Err(BccError::AttachPerfEvent { ev_type, ev_config });
+                return Err(());
             }
         } else if let Ok(cpus) = cpuonline::get() {
             for i in cpus {
@@ -62,7 +61,7 @@ impl PerfEvent {
                 };
 
                 if ptr < 0 {
-                    return Err(BccError::AttachPerfEvent { ev_type, ev_config });
+                    return Err(());
                 }
             }
         }

--- a/src/core/perf_event/v0_4_0.rs
+++ b/src/core/perf_event/v0_4_0.rs
@@ -1,4 +1,3 @@
-
 use crate::cpuonline;
 use crate::BccError;
 

--- a/src/core/perf_event/v0_4_0.rs
+++ b/src/core/perf_event/v0_4_0.rs
@@ -1,6 +1,5 @@
-use crate::core::BPF;
+
 use crate::cpuonline;
-use crate::perf::{Event, EventType};
 use crate::BccError;
 
 use bcc_sys::bccapi::*;
@@ -8,101 +7,6 @@ use bcc_sys::bccapi::*;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
 use std::os::unix::prelude::*;
-
-#[derive(Default)]
-pub struct PerfEventBuilder {
-    name: Option<String>,
-    event: Option<Event>,
-    sample_period: Option<u64>,
-    sample_freq: Option<u64>,
-    pid: Option<i32>,
-    cpu: Option<usize>,
-    group_fd: Option<i32>,
-}
-
-impl PerfEventBuilder {
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    pub fn name(mut self, name: &str) -> Self {
-        self.name = Some(name.to_owned());
-        self
-    }
-
-    pub fn event(mut self, event: Event) -> Self {
-        self.event = Some(event);
-        self
-    }
-
-    pub fn sample_period(mut self, sample_period: Option<u64>) -> Self {
-        self.sample_period = sample_period;
-        self
-    }
-
-    pub fn sample_freq(mut self, sample_freq: Option<u64>) -> Self {
-        self.sample_freq = sample_freq;
-        self
-    }
-
-    pub fn pid(mut self, pid: Option<i32>) -> Self {
-        self.pid = pid;
-        self
-    }
-
-    pub fn cpu(mut self, cpu: Option<usize>) -> Self {
-        self.cpu = cpu;
-        self
-    }
-
-    pub fn group_fd(mut self, group_fd: Option<i32>) -> Self {
-        self.group_fd = group_fd;
-        self
-    }
-
-    pub fn attach(self, bpf: &mut BPF) -> Result<(), BccError> {
-        if self.event.is_none() {
-            return Err(BccError::IncompletePerfEventBuilder {
-                field: "event".to_string(),
-            });
-        }
-        if self.name.is_none() {
-            return Err(BccError::IncompletePerfEventBuilder {
-                field: "name".to_string(),
-            });
-        }
-        let name = self.name.unwrap();
-        let event = self.event.unwrap();
-
-        let code_fd = bpf.load_perf_event(&name)?;
-
-        let ev_type = match event {
-            Event::Hardware(_) => EventType::Hardware,
-            Event::Software(_) => EventType::Software,
-            Event::HardwareCache(_, _, _) => EventType::HardwareCache,
-        } as u32;
-
-        let ev_config = match event {
-            Event::Hardware(hw_event) => hw_event as u32,
-            Event::Software(sw_event) => sw_event as u32,
-            Event::HardwareCache(id, op, result) => {
-                ((result as u32) << 16) | ((op as u32) << 8) | (id as u32)
-            }
-        };
-        let perf_event = PerfEvent::new(
-            code_fd,
-            ev_type,
-            ev_config,
-            self.sample_period.unwrap_or(0),
-            self.sample_freq.unwrap_or(0),
-            self.pid.unwrap_or(-1),
-            self.cpu,
-            self.group_fd.unwrap_or(-1),
-        )?;
-        bpf.perf_events.insert(perf_event);
-        Ok(())
-    }
-}
 
 #[derive(Debug)]
 pub struct PerfEvent {
@@ -114,7 +18,7 @@ pub struct PerfEvent {
 
 impl PerfEvent {
     #[allow(clippy::too_many_arguments)]
-    fn new(
+    pub fn new(
         code: File,
         ev_type: u32,
         ev_config: u32,
@@ -170,35 +74,6 @@ impl PerfEvent {
             p: vec,
             code_fd: code,
         })
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn attach_perf_event(
-        code: File,
-        event_type: u32,
-        event_config: u32,
-        sample_period: Option<u64>,
-        sample_freq: Option<u64>,
-        pid: Option<i32>,
-        cpu: Option<usize>,
-        group_fd: Option<i32>,
-    ) -> Result<Self, BccError> {
-        let event_type = event_type;
-        let event_config = event_config;
-        let sample_period = sample_period.unwrap_or(0);
-        let sample_freq = sample_freq.unwrap_or(0);
-        let pid = pid.unwrap_or(-1);
-        let group_fd = group_fd.unwrap_or(-1);
-        PerfEvent::new(
-            code,
-            event_type,
-            event_config,
-            sample_period,
-            sample_freq,
-            pid,
-            cpu,
-            group_fd,
-        )
     }
 }
 

--- a/src/core/perf_event/v0_4_0.rs
+++ b/src/core/perf_event/v0_4_0.rs
@@ -1,4 +1,6 @@
+use crate::core::BPF;
 use crate::cpuonline;
+use crate::perf::{Event, EventType};
 use crate::BccError;
 
 use bcc_sys::bccapi::*;
@@ -6,6 +8,101 @@ use bcc_sys::bccapi::*;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
 use std::os::unix::prelude::*;
+
+#[derive(Default)]
+pub struct PerfEventBuilder {
+    name: Option<String>,
+    event: Option<Event>,
+    sample_period: Option<u64>,
+    sample_freq: Option<u64>,
+    pid: Option<i32>,
+    cpu: Option<usize>,
+    group_fd: Option<i32>,
+}
+
+impl PerfEventBuilder {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn name(mut self, name: &str) -> Self {
+        self.name = Some(name.to_owned());
+        self
+    }
+
+    pub fn event(mut self, event: Event) -> Self {
+        self.event = Some(event);
+        self
+    }
+
+    pub fn sample_period(mut self, sample_period: Option<u64>) -> Self {
+        self.sample_period = sample_period;
+        self
+    }
+
+    pub fn sample_freq(mut self, sample_freq: Option<u64>) -> Self {
+        self.sample_freq = sample_freq;
+        self
+    }
+
+    pub fn pid(mut self, pid: Option<i32>) -> Self {
+        self.pid = pid;
+        self
+    }
+
+    pub fn cpu(mut self, cpu: Option<usize>) -> Self {
+        self.cpu = cpu;
+        self
+    }
+
+    pub fn group_fd(mut self, group_fd: Option<i32>) -> Self {
+        self.group_fd = group_fd;
+        self
+    }
+
+    pub fn attach(self, bpf: &mut BPF) -> Result<(), BccError> {
+        if self.event.is_none() {
+            return Err(BccError::IncompletePerfEventBuilder {
+                field: "event".to_string(),
+            });
+        }
+        if self.name.is_none() {
+            return Err(BccError::IncompletePerfEventBuilder {
+                field: "name".to_string(),
+            });
+        }
+        let name = self.name.unwrap();
+        let event = self.event.unwrap();
+
+        let code_fd = bpf.load_perf_event(&name)?;
+
+        let ev_type = match event {
+            Event::Hardware(_) => EventType::Hardware,
+            Event::Software(_) => EventType::Software,
+            Event::HardwareCache(_, _, _) => EventType::HardwareCache,
+        } as u32;
+
+        let ev_config = match event {
+            Event::Hardware(hw_event) => hw_event as u32,
+            Event::Software(sw_event) => sw_event as u32,
+            Event::HardwareCache(id, op, result) => {
+                ((result as u32) << 16) | ((op as u32) << 8) | (id as u32)
+            }
+        };
+        let perf_event = PerfEvent::new(
+            code_fd,
+            ev_type,
+            ev_config,
+            self.sample_period.unwrap_or(0),
+            self.sample_freq.unwrap_or(0),
+            self.pid.unwrap_or(-1),
+            self.cpu,
+            self.group_fd.unwrap_or(-1),
+        )?;
+        bpf.perf_events.insert(perf_event);
+        Ok(())
+    }
+}
 
 #[derive(Debug)]
 pub struct PerfEvent {

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,8 @@ pub enum BccError {
     Compilation,
     #[error("io error")]
     IoError(#[from] std::io::Error),
+    #[error("perf event builder has incomplete configuration")]
+    IncompletePerfEventBuilder { field: String },
     #[error("error initializing perf map")]
     InitializePerfMap,
     #[error("invalid cpu range ({range})")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,8 +20,8 @@ pub enum BccError {
     Compilation,
     #[error("io error")]
     IoError(#[from] std::io::Error),
-    #[error("perf event builder has incomplete configuration")]
-    IncompletePerfEventBuilder { field: String },
+    #[error("perf event probe has incomplete configuration")]
+    IncompletePerfEventProbe { field: String },
     #[error("error initializing perf map")]
     InitializePerfMap,
     #[error("invalid cpu range ({range})")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use crate::perf::Event;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -6,8 +7,8 @@ pub enum BccError {
     AttachKprobe { name: String },
     #[error("failed to attach kretprobe ({name})")]
     AttachKretprobe { name: String },
-    #[error("failed to attach perf event (type: {ev_type} config: {ev_config})")]
-    AttachPerfEvent { ev_type: u32, ev_config: u32 },
+    #[error("failed to attach perf event ({event:?})")]
+    AttachPerfEvent { event: Event },
     #[error("failed to attach raw tracepoint ({name})")]
     AttachRawTracepoint { name: String },
     #[error("failed to attach tracepoint ({subsys}:{name})")]

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -17,6 +17,7 @@ pub enum Event {
     HardwareCache(CacheId, CacheOp, CacheResult),
 }
 
+#[derive(Copy, Clone, Debug)]
 pub enum EventType {
     // From perf_type_id in uapi/linux/perf_event.h
     Hardware = 0,

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -22,6 +22,14 @@ pub enum EventType {
     Max, // non-ABI
 }
 
+#[derive(Copy, Clone, Debug)]
+pub enum Event {
+    Hardware(HardwareEvent),
+    Software(SoftwareEvent),
+    HardwareCache(CacheId, CacheOp, CacheResult),
+}
+
+#[derive(Copy, Clone, Debug)]
 pub enum HardwareEvent {
     // From perf_hw_id in uapi/linux/perf_event.h
     CpuCycles = 0,
@@ -38,6 +46,7 @@ pub enum HardwareEvent {
     Max, // non-ABI
 }
 
+#[derive(Copy, Clone, Debug)]
 pub enum SoftwareEvent {
     // From perf_sw_id in uapi/linux/perf_event.h
     CpuClock = 0,
@@ -55,6 +64,7 @@ pub enum SoftwareEvent {
     Max, // non-ABI
 }
 
+#[derive(Copy, Clone, Debug)]
 pub enum CacheId {
     // From perf_hw_cache_id in uapi/linux/perf_event.h
     L1D = 0,
@@ -68,6 +78,7 @@ pub enum CacheId {
     Max, // non-ABI
 }
 
+#[derive(Copy, Clone, Debug)]
 pub enum CacheOp {
     // From perf_hw_cache_op_id in uapi/linux/perf_event.h
     Read = 0,
@@ -77,6 +88,7 @@ pub enum CacheOp {
     Max, // non-ABI
 }
 
+#[derive(Copy, Clone, Debug)]
 pub enum CacheResult {
     // From perf_hw_cache_op_result_id in uapi/linux/perf_event.h
     Access = 0,

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -10,6 +10,13 @@ use crate::table::Table;
 use crate::types::*;
 use crate::BccError;
 
+#[derive(Copy, Clone, Debug)]
+pub enum Event {
+    Hardware(HardwareEvent),
+    Software(SoftwareEvent),
+    HardwareCache(CacheId, CacheOp, CacheResult),
+}
+
 pub enum EventType {
     // From perf_type_id in uapi/linux/perf_event.h
     Hardware = 0,
@@ -20,13 +27,6 @@ pub enum EventType {
     Breakpoint = 5,
 
     Max, // non-ABI
-}
-
-#[derive(Copy, Clone, Debug)]
-pub enum Event {
-    Hardware(HardwareEvent),
-    Software(SoftwareEvent),
-    HardwareCache(CacheId, CacheOp, CacheResult),
 }
 
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
* what problem are you trying to solve? (or if there's no problem, what's the motivation for this
  change?)

Function signature for attaching perf events is quite long and currently requires the caller to initialize the event config. 

* what changes does this pull request make?

Adds a PerfEventProbe which can construct and attach a PerfEvent. Following a modified builder pattern allows us to reduce the function signature complexity. Additionally, we add a new enum which allows us to specify the event type and configuration thereby making it easier on the caller particularly for initializing PerfEvents for HardwareCache counters.

* are there any non-obvious implications of these changes? (does it break compatibility with previous
  versions, etc)

Does change the API for perf events. Should be acceptable given that hasn't been included in a release yet
