### PR TITLE
refactor kprobes

### DIFF
--- a/examples/tcpretrans.rs
+++ b/examples/tcpretrans.rs
@@ -1,4 +1,4 @@
-use bcc::core::BPF;
+use bcc::core::{KernelProbe, BPF};
 use bcc::BccError;
 use chrono::Utc;
 use clap::{App, Arg};
@@ -55,9 +55,10 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     let code = include_str!("tcpretrans.c");
     // compile the above BPF code!
     let mut bpf = BPF::new(&code)?;
-
-    let trace_retransmit = bpf.load_kprobe("trace_retransmit")?;
-    bpf.attach_kprobe("tcp_retransmit_skb", trace_retransmit)?;
+    KernelProbe::new()
+        .name("trace_retransmit")
+        .function("tcp_retransmit_skb")
+        .attach(&mut bpf)?;
 
     let table = bpf.table("ipv4_events");
     bpf.init_perf_map(table, print_ipv4_event)?;

--- a/src/core/kprobe/mod.rs
+++ b/src/core/kprobe/mod.rs
@@ -43,3 +43,197 @@ mod v0_9_0;
     not(feature = "specific"),
 ))]
 pub use v0_9_0::*;
+
+use crate::core::make_alphanumeric;
+use crate::core::BPF;
+use crate::error::BccError;
+
+use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_ENTRY as BPF_PROBE_ENTRY;
+use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_RETURN as BPF_PROBE_RETURN;
+use bcc_sys::bccapi::bpf_prog_type_BPF_PROG_TYPE_KPROBE as BPF_PROG_TYPE_KPROBE;
+use regex::Regex;
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+
+#[derive(Default)]
+/// A `KernelProbe` is used to configure and then attach a kprobe to a kernel
+/// function on entry into that function. Must be attached to a `BPF` struct to
+/// be useful.
+pub struct KernelProbe {
+    name: Option<String>,
+    function: Option<String>,
+}
+
+impl KernelProbe {
+    /// Create a new probe with the defaults. Further initialization is required
+    /// before attaching.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Specify the name of the probe handler within the BPF code. This is a
+    /// required item.
+    pub fn name(mut self, name: &str) -> Self {
+        self.name = Some(name.to_owned());
+        self
+    }
+
+    /// Specify the name of the kernel function to be probed. This is a required
+    /// function.
+    pub fn function(mut self, function: &str) -> Self {
+        self.function = Some(function.to_owned());
+        self
+    }
+
+    /// Consumes the probe and attaches it to the `BPF` struct. May return an
+    /// error if there is a incomplete configuration or error while loading or
+    /// attaching the probe.
+    pub fn attach(self, bpf: &mut BPF) -> Result<(), BccError> {
+        if self.name.is_none() {
+            return Err(BccError::IncompleteKernelProbe {
+                message: "name is required".to_string(),
+            });
+        }
+        if self.function.is_none() {
+            return Err(BccError::IncompleteKernelProbe {
+                message: "function is required".to_string(),
+            });
+        }
+        let name = self.name.unwrap();
+        let function = self.function.unwrap();
+        let code_fd = bpf.load(&name, BPF_PROG_TYPE_KPROBE, 0, 0)?;
+        let name = format!("p_{}", &make_alphanumeric(&function));
+        let kprobe = Kprobe::new(&name, BPF_PROBE_ENTRY, &function, code_fd)?;
+        bpf.kprobes.insert(kprobe);
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+/// A `KernelReturnProbe` is used to configure and then attach a kretprobe to a
+/// kernel function on return from that function. Must be attached to a `BPF`
+/// struct to be useful.
+pub struct KernelReturnProbe {
+    name: Option<String>,
+    function: Option<String>,
+}
+
+impl KernelReturnProbe {
+    /// Create a new probe with the defaults. Further initialization is required
+    /// before attaching.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Specify the name of the probe handler within the BPF code. This is a
+    /// required item.
+    pub fn name(mut self, name: &str) -> Self {
+        self.name = Some(name.to_owned());
+        self
+    }
+
+    /// Specify the name of the kernel function to be probed. This is a required
+    /// function.
+    pub fn function(mut self, function: &str) -> Self {
+        self.function = Some(function.to_owned());
+        self
+    }
+
+    /// Consumes the probe and attaches it to the `BPF` struct. May return an
+    /// error if there is a incomplete configuration or error while loading or
+    /// attaching the probe.
+    pub fn attach(self, bpf: &mut BPF) -> Result<(), BccError> {
+        if self.name.is_none() {
+            return Err(BccError::IncompleteKernelProbe {
+                message: "name is required".to_string(),
+            });
+        }
+        if self.function.is_none() {
+            return Err(BccError::IncompleteKernelProbe {
+                message: "function is required".to_string(),
+            });
+        }
+        let name = self.name.unwrap();
+        let function = self.function.unwrap();
+        let code_fd = bpf.load(&name, BPF_PROG_TYPE_KPROBE, 0, 0)?;
+        let name = format!("r_{}", &make_alphanumeric(&function));
+        let kprobe = Kprobe::new(&name, BPF_PROBE_RETURN, &function, code_fd)?;
+        bpf.kprobes.insert(kprobe);
+        Ok(())
+    }
+}
+
+pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>, BccError> {
+    let mut fns: Vec<String> = vec![];
+
+    enum Section {
+        Unmatched,
+        Begin,
+        End,
+    }
+
+    let mut in_init_section = Section::Unmatched;
+    let mut in_irq_section = Section::Unmatched;
+    let re = Regex::new(r"^.*\.cold\.\d+$").unwrap();
+    let avali = BufReader::new(File::open("/proc/kallsyms").unwrap());
+    for line in avali.lines() {
+        let line = line.unwrap();
+        let cols: Vec<&str> = line.split_whitespace().collect();
+        let (t, fname) = (cols[1].to_string().to_lowercase(), cols[2]);
+        // Skip all functions defined between __init_begin and
+        // __init_end
+        match in_init_section {
+            Section::Unmatched => {
+                if fname == "__init_begin" {
+                    in_init_section = Section::Begin;
+                    continue;
+                }
+            }
+            Section::Begin => {
+                if fname == "__init_end" {
+                    in_init_section = Section::End;
+                }
+                continue;
+            }
+            Section::End => (),
+        }
+        // Skip all functions defined between __irqentry_text_start and
+        // __irqentry_text_end
+        match in_irq_section {
+            Section::Unmatched => {
+                if fname == "__irqentry_text_start" {
+                    in_irq_section = Section::Begin;
+                    continue;
+                }
+            }
+            Section::Begin => {
+                if fname == "__irqentry_text_end" {
+                    in_irq_section = Section::End;
+                }
+                continue;
+            }
+            Section::End => (),
+        }
+        // All functions defined as NOKPROBE_SYMBOL() start with the
+        // prefix _kbl_addr_*, excluding them by looking at the name
+        // allows to catch also those symbols that are defined in kernel
+        // modules.
+        if fname.starts_with("_kbl_addr_") {
+            continue;
+        }
+        // Exclude perf-related functions, they are all non-attachable.
+        if fname.starts_with("__perf") || fname.starts_with("perf_") {
+            continue;
+        }
+        // Exclude all gcc 8's extra .cold functions
+        if re.is_match(fname) {
+            continue;
+        }
+        if (t == "t" || t == "w") && fname.contains(event_re) {
+            fns.push(fname.to_owned());
+        }
+    }
+
+    Ok(fns)
+}

--- a/src/core/kprobe/v0_4_0.rs
+++ b/src/core/kprobe/v0_4_0.rs
@@ -2,16 +2,12 @@ use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_ENTRY as BPF_PROBE_ENTRY;
 use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_RETURN as BPF_PROBE_RETURN;
 use bcc_sys::bccapi::*;
 
-use crate::core::make_alphanumeric;
 use crate::types::MutPointer;
 use crate::BccError;
-
-use regex::Regex;
 
 use std::ffi::CString;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
-use std::io::{BufRead, BufReader};
 use std::os::unix::prelude::*;
 use std::ptr;
 
@@ -23,7 +19,7 @@ pub struct Kprobe {
 }
 
 impl Kprobe {
-    fn new(name: &str, attach_type: u32, function: &str, code: File) -> Result<Self, BccError> {
+    pub fn new(name: &str, attach_type: u32, function: &str, code: File) -> Result<Self, BccError> {
         let cname = CString::new(name)?;
         let cfunction = CString::new(function)?;
         let (pid, cpu, group_fd) = (-1, 0, -1);
@@ -57,90 +53,6 @@ impl Kprobe {
                 code_fd: code,
             })
         }
-    }
-
-    pub fn attach_kprobe(function: &str, code: File) -> Result<Self, BccError> {
-        let name = format!("p_{}", &make_alphanumeric(function));
-        Kprobe::new(&name, BPF_PROBE_ENTRY, function, code)
-    }
-
-    pub fn attach_kretprobe(function: &str, code: File) -> Result<Self, BccError> {
-        let name = format!("r_{}", &make_alphanumeric(function));
-        Kprobe::new(&name, BPF_PROBE_RETURN, function, code)
-    }
-
-    pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>, BccError> {
-        let mut fns: Vec<String> = vec![];
-
-        enum Section {
-            Unmatched,
-            Begin,
-            End,
-        }
-
-        let mut in_init_section = Section::Unmatched;
-        let mut in_irq_section = Section::Unmatched;
-        let re = Regex::new(r"^.*\.cold\.\d+$").unwrap();
-        let avali = BufReader::new(File::open("/proc/kallsyms").unwrap());
-        for line in avali.lines() {
-            let line = line.unwrap();
-            let cols: Vec<&str> = line.split_whitespace().collect();
-            let (t, fname) = (cols[1].to_string().to_lowercase(), cols[2]);
-            // Skip all functions defined between __init_begin and
-            // __init_end
-            match in_init_section {
-                Section::Unmatched => {
-                    if fname == "__init_begin" {
-                        in_init_section = Section::Begin;
-                        continue;
-                    }
-                }
-                Section::Begin => {
-                    if fname == "__init_end" {
-                        in_init_section = Section::End;
-                    }
-                    continue;
-                }
-                Section::End => (),
-            }
-            // Skip all functions defined between __irqentry_text_start and
-            // __irqentry_text_end
-            match in_irq_section {
-                Section::Unmatched => {
-                    if fname == "__irqentry_text_start" {
-                        in_irq_section = Section::Begin;
-                        continue;
-                    }
-                }
-                Section::Begin => {
-                    if fname == "__irqentry_text_end" {
-                        in_irq_section = Section::End;
-                    }
-                    continue;
-                }
-                Section::End => (),
-            }
-            // All functions defined as NOKPROBE_SYMBOL() start with the
-            // prefix _kbl_addr_*, excluding them by looking at the name
-            // allows to catch also those symbols that are defined in kernel
-            // modules.
-            if fname.starts_with("_kbl_addr_") {
-                continue;
-            }
-            // Exclude perf-related functions, they are all non-attachable.
-            if fname.starts_with("__perf") || fname.starts_with("perf_") {
-                continue;
-            }
-            // Exclude all gcc 8's extra .cold functions
-            if re.is_match(fname) {
-                continue;
-            }
-            if (t == "t" || t == "w") && fname.contains(event_re) {
-                fns.push(fname.to_owned());
-            }
-        }
-
-        Ok(fns)
     }
 }
 

--- a/src/core/kprobe/v0_6_0.rs
+++ b/src/core/kprobe/v0_6_0.rs
@@ -2,15 +2,11 @@ use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_ENTRY as BPF_PROBE_ENTRY;
 use bcc_sys::bccapi::bpf_probe_attach_type_BPF_PROBE_RETURN as BPF_PROBE_RETURN;
 use bcc_sys::bccapi::*;
 
-use crate::core::make_alphanumeric;
 use crate::BccError;
-
-use regex::Regex;
 
 use std::ffi::CString;
 use std::fs::File;
 use std::hash::{Hash, Hasher};
-use std::io::{BufRead, BufReader};
 use std::os::unix::prelude::*;
 
 #[derive(Debug)]
@@ -21,7 +17,7 @@ pub struct Kprobe {
 }
 
 impl Kprobe {
-    fn new(name: &str, attach_type: u32, function: &str, code: File) -> Result<Self, BccError> {
+    pub fn new(name: &str, attach_type: u32, function: &str, code: File) -> Result<Self, BccError> {
         let cname = CString::new(name)?;
         let cfunction = CString::new(function)?;
         let ptr = unsafe {
@@ -50,90 +46,6 @@ impl Kprobe {
                 code_fd: code,
             })
         }
-    }
-
-    pub fn attach_kprobe(function: &str, code: File) -> Result<Self, BccError> {
-        let name = format!("p_{}", &make_alphanumeric(function));
-        Kprobe::new(&name, BPF_PROBE_ENTRY, function, code)
-    }
-
-    pub fn attach_kretprobe(function: &str, code: File) -> Result<Self, BccError> {
-        let name = format!("r_{}", &make_alphanumeric(function));
-        Kprobe::new(&name, BPF_PROBE_RETURN, function, code)
-    }
-
-    pub fn get_kprobe_functions(event_re: &str) -> Result<Vec<String>, BccError> {
-        let mut fns: Vec<String> = vec![];
-
-        enum Section {
-            Unmatched,
-            Begin,
-            End,
-        }
-
-        let mut in_init_section = Section::Unmatched;
-        let mut in_irq_section = Section::Unmatched;
-        let re = Regex::new(r"^.*\.cold\.\d+$").unwrap();
-        let avali = BufReader::new(File::open("/proc/kallsyms").unwrap());
-        for line in avali.lines() {
-            let line = line.unwrap();
-            let cols: Vec<&str> = line.split_whitespace().collect();
-            let (t, fname) = (cols[1].to_string().to_lowercase(), cols[2]);
-            // Skip all functions defined between __init_begin and
-            // __init_end
-            match in_init_section {
-                Section::Unmatched => {
-                    if fname == "__init_begin" {
-                        in_init_section = Section::Begin;
-                        continue;
-                    }
-                }
-                Section::Begin => {
-                    if fname == "__init_end" {
-                        in_init_section = Section::End;
-                    }
-                    continue;
-                }
-                Section::End => (),
-            }
-            // Skip all functions defined between __irqentry_text_start and
-            // __irqentry_text_end
-            match in_irq_section {
-                Section::Unmatched => {
-                    if fname == "__irqentry_text_start" {
-                        in_irq_section = Section::Begin;
-                        continue;
-                    }
-                }
-                Section::Begin => {
-                    if fname == "__irqentry_text_end" {
-                        in_irq_section = Section::End;
-                    }
-                    continue;
-                }
-                Section::End => (),
-            }
-            // All functions defined as NOKPROBE_SYMBOL() start with the
-            // prefix _kbl_addr_*, excluding them by looking at the name
-            // allows to catch also those symbols that are defined in kernel
-            // modules.
-            if fname.starts_with("_kbl_addr_") {
-                continue;
-            }
-            // Exclude perf-related functions, they are all non-attachable.
-            if fname.starts_with("__perf") || fname.starts_with("perf_") {
-                continue;
-            }
-            // Exclude all gcc 8's extra .cold functions
-            if re.is_match(fname) {
-                continue;
-            }
-            if (t == "t" || t == "w") && fname.contains(event_re) {
-                fns.push(fname.to_owned());
-            }
-        }
-
-        Ok(fns)
     }
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,6 +4,7 @@ mod raw_tracepoint;
 mod tracepoint;
 mod uprobe;
 
+pub use crate::core::kprobe::{KernelProbe, KernelReturnProbe};
 pub use crate::core::perf_event::PerfEventProbe;
 
 use bcc_sys::bccapi::*;
@@ -165,10 +166,6 @@ impl BPF {
 
     pub fn load_net(&mut self, name: &str) -> Result<File, BccError> {
         self.load(name, bpf_prog_type_BPF_PROG_TYPE_SCHED_ACT, 0, 0)
-    }
-
-    pub fn load_kprobe(&mut self, name: &str) -> Result<File, BccError> {
-        self.load(name, bpf_prog_type_BPF_PROG_TYPE_KPROBE, 0, 0)
     }
 
     pub fn load_uprobe(&mut self, name: &str) -> Result<File, BccError> {
@@ -369,20 +366,8 @@ impl BPF {
         Ok(())
     }
 
-    pub fn attach_kprobe(&mut self, function: &str, file: File) -> Result<(), BccError> {
-        let kprobe = Kprobe::attach_kprobe(function, file)?;
-        self.kprobes.insert(kprobe);
-        Ok(())
-    }
-
-    pub fn attach_kretprobe(&mut self, function: &str, file: File) -> Result<(), BccError> {
-        let kretprobe = Kprobe::attach_kretprobe(function, file)?;
-        self.kprobes.insert(kretprobe);
-        Ok(())
-    }
-
     pub fn get_kprobe_functions(&mut self, event_re: &str) -> Result<Vec<String>, BccError> {
-        Kprobe::get_kprobe_functions(event_re)
+        crate::core::kprobe::get_kprobe_functions(event_re)
     }
 
     pub fn attach_uprobe(

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,8 @@ pub enum BccError {
     Compilation,
     #[error("io error")]
     IoError(#[from] std::io::Error),
+    #[error("kernel probe has incomplete configuration: {message}")]
+    IncompleteKernelProbe { message: String },
     #[error("perf event probe has incomplete configuration")]
     IncompletePerfEventProbe { field: String },
     #[error("error initializing perf map")]


### PR DESCRIPTION
Refactor kprobes to use a builder-style pattern for constructing
and attaching the probes.

Reduces code duplication between various version-specific
implementations.
