### PR TITLE
rename probe 'name' to 'handler'

### DIFF
--- a/examples/biosnoop.rs
+++ b/examples/biosnoop.rs
@@ -57,21 +57,21 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
 
     // attach kprobes
     Kprobe::new()
-        .name("trace_pid_start")
+        .handler("trace_pid_start")
         .function("blk_account_io_start")
         .attach(&mut bpf)?;
     Kprobe::new()
-        .name("trace_req_start")
+        .handler("trace_req_start")
         .function("blk_mq_start_request")
         .attach(&mut bpf)?;
     Kprobe::new()
-        .name("trace_req_completion")
+        .handler("trace_req_completion")
         .function("blk_account_io_completion")
         .attach(&mut bpf)?;
     if let Ok(funcs) = bpf.get_kprobe_functions("blk_start_request") {
         if funcs.len() > 0 {
             Kprobe::new()
-                .name("trace_req_start")
+                .handler("trace_req_start")
                 .function("blk_start_request")
                 .attach(&mut bpf)?;
         }

--- a/examples/contextswitch.rs
+++ b/examples/contextswitch.rs
@@ -96,7 +96,7 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
 
     let mut bpf = BPF::new(&code)?;
     PerfEvent::new()
-        .name("do_count")
+        .handler("do_count")
         .event(Event::Software(SoftwareEvent::ContextSwitches))
         .sample_period(sample_period)
         .sample_frequency(sample_frequency)

--- a/examples/llcstat.rs
+++ b/examples/llcstat.rs
@@ -54,12 +54,12 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     let code = include_str!("llcstat.c").to_string();
     let mut bpf = BPF::new(&code)?;
     PerfEvent::new()
-        .name("on_cache_miss")
+        .handler("on_cache_miss")
         .event(Event::Hardware(HardwareEvent::CacheMisses))
         .sample_period(Some(sample_period))
         .attach(&mut bpf)?;
     PerfEvent::new()
-        .name("on_cache_ref")
+        .handler("on_cache_ref")
         .event(Event::Hardware(HardwareEvent::CacheReferences))
         .sample_period(Some(sample_period))
         .attach(&mut bpf)?;

--- a/examples/opensnoop.rs
+++ b/examples/opensnoop.rs
@@ -50,11 +50,11 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     let mut module = BPF::new(code)?;
     // load + attach kprobes!
     Kprobe::new()
-        .name("trace_entry")
+        .handler("trace_entry")
         .function("do_sys_open")
         .attach(&mut module)?;
     Kretprobe::new()
-        .name("trace_return")
+        .handler("trace_return")
         .function("do_sys_open")
         .attach(&mut module)?;
 

--- a/examples/runqlat.rs
+++ b/examples/runqlat.rs
@@ -31,30 +31,30 @@ fn attach_events(bpf: &mut BPF) -> Result<(), BccError> {
 fn attach_events(bpf: &mut BPF) -> Result<(), BccError> {
     if bpf.support_raw_tracepoint() {
         RawTracepoint::new()
-            .name("raw_tp__sched_wakeup")
+            .handler("raw_tp__sched_wakeup")
             .tracepoint("sched_wakeup")
             .attach(bpf)?;
         RawTracepoint::new()
-            .name("raw_tp__sched_wakeup_new")
+            .handler("raw_tp__sched_wakeup_new")
             .tracepoint("sched_wakeup_new")
             .attach(bpf)?;
         RawTracepoint::new()
-            .name("raw_tp__sched_switch")
+            .handler("raw_tp__sched_switch")
             .tracepoint("sched_switch")
             .attach(bpf)?;
         Ok(())
     } else {
         // load + attach kprobes!
         Kprobe::new()
-            .name("trace_run")
+            .handler("trace_run")
             .function("finish_task_switch")
             .attach(bpf)?;
         Kprobe::new()
-            .name("trace_ttwu_do_wakeup")
+            .handler("trace_ttwu_do_wakeup")
             .function("ttwu_do_wakeup")
             .attach(bpf)?;
         Kprobe::new()
-            .name("trace_wake_up_new_task")
+            .handler("trace_wake_up_new_task")
             .function("wake_up_new_task")
             .attach(bpf)?;
         Ok(())

--- a/examples/softirqs.rs
+++ b/examples/softirqs.rs
@@ -117,12 +117,12 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
 
     // tracepoints!
     Tracepoint::new()
-        .name("softirq_entry")
+        .handler("softirq_entry")
         .subsystem("irq")
         .tracepoint("softirq_entry")
         .attach(&mut module)?;
     Tracepoint::new()
-        .name("softirq_exit")
+        .handler("softirq_exit")
         .subsystem("irq")
         .tracepoint("softirq_exit")
         .attach(&mut module)?;

--- a/examples/strlen.rs
+++ b/examples/strlen.rs
@@ -34,7 +34,7 @@ int count(struct pt_regs *ctx) {
     ";
     let mut module = BPF::new(code)?;
     Uprobe::new()
-        .name("count")
+        .handler("count")
         .binary("/lib/x86_64-linux-gnu/libc.so.6")
         .symbol("strlen")
         .attach(&mut module)?;

--- a/examples/tcpretrans.rs
+++ b/examples/tcpretrans.rs
@@ -56,7 +56,7 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     // compile the above BPF code!
     let mut bpf = BPF::new(&code)?;
     Kprobe::new()
-        .name("trace_retransmit")
+        .handler("trace_retransmit")
         .function("tcp_retransmit_skb")
         .attach(&mut bpf)?;
 

--- a/src/kprobe/mod.rs
+++ b/src/kprobe/mod.rs
@@ -15,7 +15,7 @@ use std::io::{BufRead, BufReader};
 /// function on entry into that function. Must be attached to a `BPF` struct to
 /// be useful.
 pub struct Kprobe {
-    name: Option<String>,
+    handler: Option<String>,
     function: Option<String>,
 }
 
@@ -28,15 +28,15 @@ impl Kprobe {
 
     /// Specify the name of the probe handler within the BPF code. This is a
     /// required item.
-    pub fn name(mut self, name: &str) -> Self {
-        self.name = Some(name.to_owned());
+    pub fn handler(mut self, name: &str) -> Self {
+        self.handler = Some(name.to_owned());
         self
     }
 
     /// Specify the name of the kernel function to be probed. This is a required
     /// function.
-    pub fn function(mut self, function: &str) -> Self {
-        self.function = Some(function.to_owned());
+    pub fn function(mut self, name: &str) -> Self {
+        self.function = Some(name.to_owned());
         self
     }
 
@@ -44,9 +44,9 @@ impl Kprobe {
     /// error if there is a incomplete configuration or error while loading or
     /// attaching the probe.
     pub fn attach(self, bpf: &mut BPF) -> Result<(), BccError> {
-        if self.name.is_none() {
+        if self.handler.is_none() {
             return Err(BccError::IncompleteKernelProbe {
-                message: "name is required".to_string(),
+                message: "handler is required".to_string(),
             });
         }
         if self.function.is_none() {
@@ -54,11 +54,11 @@ impl Kprobe {
                 message: "function is required".to_string(),
             });
         }
-        let name = self.name.unwrap();
+        let handler = self.handler.unwrap();
         let function = self.function.unwrap();
-        let code_fd = bpf.load(&name, BPF_PROG_TYPE_KPROBE, 0, 0)?;
-        let name = format!("p_{}", &make_alphanumeric(&function));
-        let kprobe = crate::core::Kprobe::new(&name, BPF_PROBE_ENTRY, &function, code_fd)?;
+        let code_fd = bpf.load(&handler, BPF_PROG_TYPE_KPROBE, 0, 0)?;
+        let handler = format!("p_{}", &make_alphanumeric(&function));
+        let kprobe = crate::core::Kprobe::new(&handler, BPF_PROBE_ENTRY, &function, code_fd)?;
         bpf.kprobes.insert(kprobe);
         Ok(())
     }
@@ -111,8 +111,8 @@ impl Kretprobe {
         let name = self.name.unwrap();
         let function = self.function.unwrap();
         let code_fd = bpf.load(&name, BPF_PROG_TYPE_KPROBE, 0, 0)?;
-        let name = format!("r_{}", &make_alphanumeric(&function));
-        let kprobe = crate::core::Kprobe::new(&name, BPF_PROBE_RETURN, &function, code_fd)?;
+        let handler = format!("r_{}", &make_alphanumeric(&function));
+        let kprobe = crate::core::Kprobe::new(&handler, BPF_PROBE_RETURN, &function, code_fd)?;
         bpf.kprobes.insert(kprobe);
         Ok(())
     }

--- a/src/kprobe/mod.rs
+++ b/src/kprobe/mod.rs
@@ -69,7 +69,7 @@ impl Kprobe {
 /// function on return from that function. Must be attached to a `BPF` struct to
 /// be useful.
 pub struct Kretprobe {
-    name: Option<String>,
+    handler: Option<String>,
     function: Option<String>,
 }
 
@@ -82,15 +82,15 @@ impl Kretprobe {
 
     /// Specify the name of the probe handler within the BPF code. This is a
     /// required item.
-    pub fn name(mut self, name: &str) -> Self {
-        self.name = Some(name.to_owned());
+    pub fn handler(mut self, name: &str) -> Self {
+        self.handler = Some(name.to_owned());
         self
     }
 
     /// Specify the name of the kernel function to be probed. This is a required
     /// function.
-    pub fn function(mut self, function: &str) -> Self {
-        self.function = Some(function.to_owned());
+    pub fn function(mut self, name: &str) -> Self {
+        self.function = Some(name.to_owned());
         self
     }
 
@@ -98,9 +98,9 @@ impl Kretprobe {
     /// error if there is a incomplete configuration or error while loading or
     /// attaching the probe.
     pub fn attach(self, bpf: &mut BPF) -> Result<(), BccError> {
-        if self.name.is_none() {
+        if self.handler.is_none() {
             return Err(BccError::IncompleteKernelProbe {
-                message: "name is required".to_string(),
+                message: "handler is required".to_string(),
             });
         }
         if self.function.is_none() {
@@ -108,9 +108,9 @@ impl Kretprobe {
                 message: "function is required".to_string(),
             });
         }
-        let name = self.name.unwrap();
+        let handler = self.handler.unwrap();
         let function = self.function.unwrap();
-        let code_fd = bpf.load(&name, BPF_PROG_TYPE_KPROBE, 0, 0)?;
+        let code_fd = bpf.load(&handler, BPF_PROG_TYPE_KPROBE, 0, 0)?;
         let handler = format!("r_{}", &make_alphanumeric(&function));
         let kprobe = crate::core::Kprobe::new(&handler, BPF_PROBE_RETURN, &function, code_fd)?;
         bpf.kprobes.insert(kprobe);

--- a/src/perf_event/perf_event.rs
+++ b/src/perf_event/perf_event.rs
@@ -6,7 +6,7 @@ use bcc_sys::bccapi::bpf_prog_type_BPF_PROG_TYPE_PERF_EVENT as BPF_PROG_TYPE_PER
 
 #[derive(Default)]
 pub struct PerfEvent {
-    name: Option<String>,
+    handler: Option<String>,
     event: Option<Event>,
     sample_period: Option<u64>,
     sample_frequency: Option<u64>,
@@ -27,8 +27,8 @@ impl PerfEvent {
 
     /// This corresponds to the function name in the BPF code which will be
     /// called when the probe fires. This is required.
-    pub fn name(mut self, name: &str) -> Self {
-        self.name = Some(name.to_owned());
+    pub fn handler(mut self, name: &str) -> Self {
+        self.handler = Some(name.to_owned());
         self
     }
 
@@ -89,9 +89,9 @@ impl PerfEvent {
                 message: "event is required".to_string(),
             });
         }
-        if self.name.is_none() {
+        if self.handler.is_none() {
             return Err(BccError::IncompletePerfEventProbe {
-                message: "name is required".to_string(),
+                message: "handler is required".to_string(),
             });
         }
         if (self.sample_period.unwrap_or(0) == 0) as i32
@@ -102,10 +102,10 @@ impl PerfEvent {
                 message: "exactly one of sample period or sample frequency is required".to_string(),
             });
         }
-        let name = self.name.unwrap();
+        let handler = self.handler.unwrap();
         let event = self.event.unwrap();
 
-        let code_fd = bpf.load(&name, BPF_PROG_TYPE_PERF_EVENT, 0, 0)?;
+        let code_fd = bpf.load(&handler, BPF_PROG_TYPE_PERF_EVENT, 0, 0)?;
 
         let ev_type = match event {
             Event::Hardware(_) => EventType::Hardware,

--- a/src/raw_tracepoint/mod.rs
+++ b/src/raw_tracepoint/mod.rs
@@ -6,7 +6,7 @@ use bcc_sys::bccapi::bpf_prog_type_BPF_PROG_TYPE_RAW_TRACEPOINT as BPF_PROG_TYPE
 #[derive(Default)]
 pub struct RawTracepoint {
     tracepoint: Option<String>,
-    name: Option<String>,
+    handler: Option<String>,
 }
 
 impl RawTracepoint {
@@ -14,13 +14,13 @@ impl RawTracepoint {
         Default::default()
     }
 
-    pub fn name(mut self, name: &str) -> Self {
-        self.name = Some(name.to_owned());
+    pub fn handler(mut self, name: &str) -> Self {
+        self.handler = Some(name.to_owned());
         self
     }
 
-    pub fn tracepoint(mut self, tracepoint: &str) -> Self {
-        self.tracepoint = Some(tracepoint.to_owned());
+    pub fn tracepoint(mut self, name: &str) -> Self {
+        self.tracepoint = Some(name.to_owned());
         self
     }
 
@@ -47,9 +47,9 @@ impl RawTracepoint {
         not(feature = "specific"),
     ))]
     pub fn attach(self, bpf: &mut BPF) -> Result<(), BccError> {
-        if self.name.is_none() {
+        if self.handler.is_none() {
             return Err(BccError::IncompleteRawTracepointProbe {
-                message: "name is required".to_string(),
+                message: "handler is required".to_string(),
             });
         }
         if self.tracepoint.is_none() {
@@ -57,12 +57,12 @@ impl RawTracepoint {
                 message: "tracepoint is required".to_string(),
             });
         }
-        let name = self.name.unwrap();
+        let handler = self.handler.unwrap();
         let tracepoint = self.tracepoint.unwrap();
-        let code_fd = bpf.load(&name, BPF_PROG_TYPE_RAW_TRACEPOINT, 0, 0)?;
+        let code_fd = bpf.load(&handler, BPF_PROG_TYPE_RAW_TRACEPOINT, 0, 0)?;
 
-        let tracepoint = crate::core::RawTracepoint::new(&tracepoint, code_fd)?;
-        bpf.raw_tracepoints.insert(tracepoint);
+        let raw_tracepoint = crate::core::RawTracepoint::new(&tracepoint, code_fd)?;
+        bpf.raw_tracepoints.insert(raw_tracepoint);
         Ok(())
     }
 }

--- a/src/uprobe/mod.rs
+++ b/src/uprobe/mod.rs
@@ -101,7 +101,7 @@ impl Uprobe {
 /// struct to be useful.
 pub struct Uretprobe {
     binary: Option<PathBuf>,
-    name: Option<String>,
+    handler: Option<String>,
     pid: Option<pid_t>,
     symbol: Option<String>,
 }
@@ -115,8 +115,8 @@ impl Uretprobe {
 
     /// Specify the name of the probe handler within the BPF code. This is a
     /// required item.
-    pub fn name(mut self, name: &str) -> Self {
-        self.name = Some(name.to_owned());
+    pub fn handler(mut self, name: &str) -> Self {
+        self.handler = Some(name.to_owned());
         self
     }
 
@@ -142,9 +142,9 @@ impl Uretprobe {
     /// error if there is a incomplete configuration or error while loading or
     /// attaching the probe.
     pub fn attach(self, bpf: &mut BPF) -> Result<(), BccError> {
-        if self.name.is_none() {
+        if self.handler.is_none() {
             return Err(BccError::IncompleteUserspaceProbe {
-                message: "name is required".to_string(),
+                message: "handler is required".to_string(),
             });
         }
         if self.binary.is_none() {
@@ -166,13 +166,13 @@ impl Uretprobe {
         let binary = binary.unwrap();
         let symbol = self.symbol.unwrap();
         let pid = self.pid.unwrap_or(-1);
-        let name = self.name.unwrap();
+        let handler = self.handler.unwrap();
 
         let (path, addr) = crate::symbol::resolve_symbol_path(&binary, &symbol, 0x0, pid)?;
         let alpha_path = make_alphanumeric(&path);
         let ev_name = format!("r_{}_0x{:x}", &alpha_path, addr);
 
-        let code_fd = bpf.load(&name, BPF_PROG_TYPE_KPROBE, 0, 0)?;
+        let code_fd = bpf.load(&handler, BPF_PROG_TYPE_KPROBE, 0, 0)?;
 
         let uprobe =
             crate::core::Uprobe::new(&ev_name, BPF_PROBE_RETURN, &path, addr, code_fd, pid)?;

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -15,7 +15,7 @@ mod tests {
         // compile the above BPF code!
         let mut module = BPF::new(code).unwrap();
         if Kprobe::new()
-            .name("trace_return")
+            .handler("trace_return")
             .function("do_sys_open")
             .attach(&mut module)
             .is_ok()


### PR DESCRIPTION
Currently, 'name' refers to the BPF function name of the probe
handler. It seems like it would be more clear to call this a
handler.
