### PR TITLE
Added Rust clone of 'execsnoop'

### DIFF
--- a/examples/execsnoop.c
+++ b/examples/execsnoop.c
@@ -1,0 +1,135 @@
+#include <uapi/linux/ptrace.h>
+#include <linux/sched.h>
+#include <linux/fs.h>
+
+#define ARGSIZE 128
+enum event_type {
+    EVENT_ARG,
+    EVENT_RET,
+};
+
+struct data_t {
+    u32 pid;  // PID as in the userspace term (i.e. task->tgid in kernel)
+    u32 ppid; // Parent PID as in the userspace term (i.e task->real_parent->tgid in kernel)
+    u32 uid; // User ID
+    char comm[TASK_COMM_LEN]; // Program name
+    enum event_type type; // Event type enum
+    char argv[ARGSIZE]; // Argument vector array
+    int retval; // System call return value
+    u32 maxarg; // Maximum command-line argument's length
+    u64 argmap_ptr; // Pointer to userland's arguments map
+};
+
+#if CGROUPSET
+BPF_TABLE_PINNED("hash", u64, u64, cgroupset, 1024, "CGROUPPATH");
+#endif
+BPF_PERF_OUTPUT(events);
+
+static int __submit_arg(struct pt_regs *ctx, void *ptr, struct data_t *data)
+{
+    bpf_probe_read_user(data->argv, sizeof(data->argv), ptr);
+    events.perf_submit(ctx, data, sizeof(struct data_t));
+    return 1;
+}
+
+static int submit_arg(struct pt_regs *ctx, void *ptr, struct data_t *data)
+{
+    const char *argp = NULL;
+    bpf_probe_read_user(&argp, sizeof(argp), ptr);
+    if (argp) {
+        return __submit_arg(ctx, (void *)(argp), data);
+    }
+    return 0;
+}
+
+int syscall_execve(struct pt_regs *ctx,
+    const char __user *filename,
+    const char __user *const __user *__argv,
+    const char __user *const __user *__envp)
+{
+    u32 uid = bpf_get_current_uid_gid() & 0xffffffff;
+    UID_FILTER
+#if CGROUPSET
+    u64 cgroupid = bpf_get_current_cgroup_id();
+    if (cgroupset.lookup(&cgroupid) == NULL) {
+      return 0;
+    }
+#endif
+    // create data here and pass to submit_arg to save stack space (#555)
+    struct data_t data = {};
+    struct task_struct *task;
+    // store pointer to initialized arguments map in userland
+    data.argmap_ptr = ARGMAP_PTR;
+    data.pid = bpf_get_current_pid_tgid() >> 32;
+#if PIDSET
+    if ($PID != data.pid) {
+        return 0;
+    }
+#endif
+    task = (struct task_struct *)bpf_get_current_task();
+    // Some kernels, like Ubuntu 4.13.0-generic, return 0
+    // as the real_parent->tgid.
+    // We use the get_ppid function as a fallback in those cases. (#1883)
+    data.ppid = task->real_parent->tgid;
+#if PPIDSET
+    if ($PPID != data.ppid) {
+        return 0;
+    }
+#endif
+    bpf_get_current_comm(&data.comm, sizeof(data.comm));
+    data.type = EVENT_ARG;
+    // set max argument width
+    data.maxarg = MAXARG;
+    __submit_arg(ctx, (void *)filename, &data);
+    // skip first arg, as we submitted filename
+    #pragma unroll
+    for (int i = 1; i < MAXARG; i++) {
+        if (submit_arg(ctx, (void *)&__argv[i], &data) == 0)
+             goto out;
+    }
+    // handle truncated argument list
+    char ellipsis[] = "...";
+    __submit_arg(ctx, (void *)ellipsis, &data);
+out:
+    return 0;
+}
+
+int ret_sys_execve(struct pt_regs *ctx)
+{
+#if CGROUPSET
+    u64 cgroupid = bpf_get_current_cgroup_id();
+    if (cgroupset.lookup(&cgroupid) == NULL) {
+      return 0;
+    }
+#endif
+    struct data_t data = {};
+    struct task_struct *task;
+    // store pointer to initialized arguments map in userland
+    data.argmap_ptr = ARGMAP_PTR;
+    u32 uid = bpf_get_current_uid_gid() & 0xffffffff;
+    data.uid = uid;
+    UID_FILTER
+    data.pid = bpf_get_current_pid_tgid() >> 32;
+#if PIDSET
+    if ($PID != data.pid) {
+        return 0;
+    }
+#endif
+    task = (struct task_struct *)bpf_get_current_task();
+    // Some kernels, like Ubuntu 4.13.0-generic, return 0
+    // as the real_parent->tgid.
+    // We use the get_ppid function as a fallback in those cases. (#1883)
+    data.ppid = task->real_parent->tgid;
+#if PPIDSET
+    if ($PPID != data.ppid) {
+        return 0;
+    }
+#endif
+    bpf_get_current_comm(&data.comm, sizeof(data.comm));
+    data.type = EVENT_RET;
+    data.retval = PT_REGS_RC(ctx);
+    // set max argument width
+    data.maxarg = MAXARG;
+    events.perf_submit(ctx, &data, sizeof(data));
+    return 0;
+}

--- a/examples/execsnoop.rs
+++ b/examples/execsnoop.rs
@@ -232,4 +232,3 @@ fn main() {
         std::process::exit(1);
     }
 }
-

--- a/examples/execsnoop.rs
+++ b/examples/execsnoop.rs
@@ -1,0 +1,236 @@
+extern crate bcc;
+extern crate byteorder;
+extern crate failure;
+extern crate libc;
+extern crate multimap;
+
+use bcc::perf_event::init_perf_map;
+use bcc::BccError;
+use bcc::{Kprobe, Kretprobe, BPF};
+use clap::{App, Arg};
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use std::ptr;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use multimap::MultiMap;
+
+/*
+    Snoop on execve() system calls
+*/
+#[repr(C)]
+#[allow(dead_code)]
+enum event_type {
+    EventArg,
+    EventRet,
+}
+
+#[repr(C)]
+struct data_t {
+    pid: u32,          // process-id
+    ppid: u32,         // parent process-id
+    uid: u32,          // user-id
+    comm: [u8; 16],    // command name
+    etype: event_type, // event type
+    argv: [u8; 128],   // arguments vector
+    retval: u8,        // returned value
+    maxarg: u32,       // maximum argument length
+    argmap_ptr: u64,   // pointer to user-land's argmap
+}
+
+fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
+    let matches = App::new("execsnoop")
+        .about("Prints out new processes created via execve() system calls.")
+        .arg(
+            Arg::with_name("duration")
+                .long("duration")
+                .value_name("seconds")
+                .help("The total duration to run this tool")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("maxarg")
+                .long("maxarg")
+                .value_name("max arguments length")
+                .help("The maximum command-line arguments length")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("uid")
+                .long("uid")
+                .value_name("user id")
+                .help("Only print system calls running under the given user")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("pid")
+                .long("pid")
+                .value_name("process id")
+                .help("Only print system calls from given process")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("ppid")
+                .long("ppid")
+                .value_name("parent process id")
+                .help("Only print system calls from process(es) with given parent process")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let duration: Option<std::time::Duration> = matches
+        .value_of("duration")
+        .map(|v| std::time::Duration::new(v.parse().expect("Invalid argument for duration"), 0));
+    let maxarg = matches.value_of("maxarg").unwrap_or("20");
+    let userid = matches
+        .value_of("uid")
+        .map(|v| v.parse::<u32>().expect("Invalid user id"));
+    let pid: Option<u32> = matches
+        .value_of("pid")
+        .map(|v| v.parse().expect("Invalid process id"));
+    let ppid: Option<u32> = matches
+        .value_of("ppid")
+        .map(|v| v.parse().expect("Invalid parent process id"));
+    // modify bpf program source code
+    let code = include_str!("execsnoop.c");
+    // replace variables with runtime information
+    let mut c = code.replace("MAXARG", maxarg);
+    if let Some(uid) = userid {
+        let uid_filter = format!("if (uid != {}) {{ return 0; }}", uid);
+        c = c.replace("UID_FILTER", &uid_filter);
+    } else {
+        c = c.replace("UID_FILTER", "");
+    }
+    c = c.replace("CGROUPSET", "0"); // hard-coded (non-implemented)
+    if let Some(p) = pid {
+        c = c.replace("PIDSET", "1");
+        c = c.replace("$PID", &p.to_string());
+    }
+    if let Some(p) = ppid {
+        c = c.replace("PPIDSET", "1");
+        c = c.replace("$PPID", &p.to_string());
+    }
+
+    // initialize "shared" multimap on the heap (experimental)
+    let arg_map: Arc<Mutex<MultiMap<u32, String>>> = Arc::new(Mutex::new(MultiMap::new()));
+    let arg_map_c = arg_map.clone();
+    let argmap_sptr = format!("{:?}", &&arg_map_c as *const _);
+    c = c.replace("ARGMAP_PTR", &argmap_sptr);
+
+    // compile the above BPF code
+    let mut module = BPF::new(&c)?;
+    // load and attach kprobes
+    let execve_funcname = module.get_syscall_fnname("execve");
+    Kprobe::new()
+        .handler("syscall_execve")
+        .function(&execve_funcname)
+        .attach(&mut module)?;
+    Kretprobe::new()
+        .handler("ret_sys_execve")
+        .function(&execve_funcname)
+        .attach(&mut module)?;
+
+    // the "events" table is where the "execve" events get sent
+    let table = module.table("events");
+    // install a callback to print out file events when they happen
+    let mut perf_map = init_perf_map(table, perf_data_callback)?;
+
+    // print a header
+    let marg = maxarg.parse::<usize>().unwrap_or(20);
+    println!(
+        "{:-7} {:>7} {:>7}  {:<16} {:>4}  {:width$}",
+        "UID",
+        "PID",
+        "PPID",
+        "CMD",
+        "RET",
+        "ARG",
+        width = marg
+    );
+    let start = std::time::Instant::now();
+    // this `.poll()` loop is what makes our callback get called
+    while runnable.load(Ordering::SeqCst) {
+        perf_map.poll(200);
+        if let Some(d) = duration {
+            if std::time::Instant::now() - start >= d {
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// Performance Data Callback Function
+fn perf_data_callback() -> Box<dyn FnMut(&[u8]) + Send> {
+    let skip = false;
+
+    Box::new(move |x| {
+        // initialize command-line argument text String
+        let mut argv_txt = String::new();
+
+        // parse data structure of type data_t
+        let data = parse_struct(x);
+
+        // read stored argmap raw pointer
+        let argmap_ptr = data.argmap_ptr as *const u64;
+        // read data structure from raw pointer
+        let m_argmap: &Arc<Mutex<MultiMap<u32, String>>> =
+            unsafe { ptr::read(argmap_ptr as *mut &Arc<Mutex<MultiMap<u32, String>>>) };
+        let m_argmap_c = m_argmap.clone();
+        let mut arg_map = m_argmap_c.lock().unwrap();
+
+        match data.etype {
+            event_type::EventArg => {
+                arg_map.insert(data.pid, get_string(&data.argv));
+            }
+            event_type::EventRet => {
+                match arg_map.get_vec(&data.pid) {
+                    Some(v) => {
+                        argv_txt = v.join(" ");
+                    }
+                    None => {}
+                }
+                if !skip {
+                    println!(
+                        "{:<7} {:>7} {:>7}  {:<16} {:>4}  {:width$}",
+                        data.uid,
+                        data.pid,
+                        data.ppid,
+                        get_string(&data.comm),
+                        data.retval,
+                        argv_txt,
+                        width = data.maxarg as usize,
+                    );
+                }
+            }
+        }
+    })
+}
+
+fn parse_struct(x: &[u8]) -> data_t {
+    unsafe { ptr::read(x.as_ptr() as *const data_t) }
+}
+
+fn get_string(x: &[u8]) -> String {
+    match x.iter().position(|&r| r == 0) {
+        Some(zero_pos) => String::from_utf8_lossy(&x[0..zero_pos]).to_string(),
+        None => String::from_utf8_lossy(x).to_string(),
+    }
+}
+
+fn main() {
+    let runnable = Arc::new(AtomicBool::new(true));
+    let r = runnable.clone();
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    })
+    .expect("Failed to set handler for SIGINT / SIGTERM");
+
+    if let Err(x) = do_main(runnable) {
+        eprintln!("Error: {}", x);
+        std::process::exit(1);
+    }
+}
+

--- a/examples/execsnoop.rs
+++ b/examples/execsnoop.rs
@@ -1,6 +1,5 @@
 extern crate bcc;
 extern crate byteorder;
-extern crate failure;
 extern crate libc;
 extern crate multimap;
 


### PR DESCRIPTION
Hello,

* What problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
  Here is a Rust port of the iovisor/bcc's [execsnoop](https://github.com/iovisor/bcc/blob/master/tools/execsnoop.py) example tool.
* What changes does this pull request make?
  It adds the user-land utility written in Rust and a slightly modified version of the execsnoop.c file.
* Are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
  It shouldn't bring major implications, however I have chosen to use a `MultiMap` to holds the process's argument(s) vector and 
 to use a Mutex and an Arc so the object can be "safely" accessed in memory. A raw pointer to it is kept inside the `data_t` structure. Due to time constraints, this is the most elegant way I found to access the arg vectors (sorry!).
 The tool has been successfully tested on a `Linux 4.15.0-112-generic` kernel. The `CGROUPSET` filter has not been ported/implemented in the user-land part, but the filter has been preserved the bpf code.

Regards.