### PR TITLE
Fix | Probe drop do not detach perf event

### DIFF
--- a/src/core/kprobe/v0_4_0.rs
+++ b/src/core/kprobe/v0_4_0.rs
@@ -59,6 +59,7 @@ impl Kprobe {
 impl Drop for Kprobe {
     fn drop(&mut self) {
         unsafe {
+            bpf_close_perf_event_fd(self.p);
             bpf_detach_kprobe(self.name.as_ptr());
         }
     }

--- a/src/core/kprobe/v0_6_0.rs
+++ b/src/core/kprobe/v0_6_0.rs
@@ -52,6 +52,7 @@ impl Kprobe {
 impl Drop for Kprobe {
     fn drop(&mut self) {
         unsafe {
+            bpf_close_perf_event_fd(self.p);
             bpf_detach_kprobe(self.name.as_ptr());
         }
     }

--- a/src/core/kprobe/v0_9_0.rs
+++ b/src/core/kprobe/v0_9_0.rs
@@ -53,6 +53,7 @@ impl Kprobe {
 impl Drop for Kprobe {
     fn drop(&mut self) {
         unsafe {
+            bpf_close_perf_event_fd(self.p);
             bpf_detach_kprobe(self.name.as_ptr());
         }
     }

--- a/src/core/uprobe/v0_4_0.rs
+++ b/src/core/uprobe/v0_4_0.rs
@@ -68,6 +68,7 @@ impl Uprobe {
 impl Drop for Uprobe {
     fn drop(&mut self) {
         unsafe {
+            bpf_close_perf_event_fd(self.p);
             bpf_detach_uprobe(self.name.as_ptr());
         }
     }

--- a/src/core/uprobe/v0_6_0.rs
+++ b/src/core/uprobe/v0_6_0.rs
@@ -60,6 +60,7 @@ impl Uprobe {
 impl Drop for Uprobe {
     fn drop(&mut self) {
         unsafe {
+            bpf_close_perf_event_fd(self.p);
             bpf_detach_uprobe(self.name.as_ptr());
         }
     }


### PR DESCRIPTION
For some reason attaching a probe creates a perf event. Thus we need to also call `bpf_close_perf_event_fd` before detaching the probe.

Fixes #44

Note: I did not add this to tracepoints yet