### PR TITLE
Add cflags support

### DIFF
--- a/examples/smoketest.rs
+++ b/examples/smoketest.rs
@@ -50,5 +50,11 @@ fn main() {
     assert_eq!(entries.get(1).unwrap().value, [0, 0, 0, 0, 0, 0, 13, 37]);
     assert_eq!(entries.get(0).unwrap().value, [0, 0, 0, 0, 0, 0, 0, 42]);
 
+    println!("smoketest: cflags");
+    BPF::new_with_cflags(
+        "int main() { return AMAZING_RETURN_CODE; }",
+        vec!["-DAMAZING_RETURN_CODE=0"],
+    )
+    .unwrap();
     println!("smoketest passed");
 }


### PR DESCRIPTION
This PR adds support for passing a vector of cflags that will be
passed to the bcc backend and processed by clang's preprocessor

## Template

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this
  change?)

The [BCC Python](https://github.com/iovisor/bcc/blob/fc92caa08f52533dd18cff6bf9e3438c75ca5cb3/src/python/bcc/__init__.py#L292) and C++ bindings allow passing CFLAGS to the BPF program. We are using this feature in a project with a Python BCC driver and are currently experimenting with Rust so we would love to be able to use it :smile: 

* what changes does this pull request make?

Moves `bpf_module_create_c_from_string` to its own function, leaving `new` with the same signature, and adds `new_with_cflags`, to which you can pass CFLAGS has a second argument

* are there any non-obvious implications of these changes? (does it break compatibility with previous
  versions, etc)

It should not break backwards compatibility. I am a not experienced with Rust (first Rust PR!), so I am unsure if there is a better way to do this!

## Test plan
Added a simple smoke test
```
➜  rust-bcc git:(cflags-support) ✗ cargo build --examples
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
➜  rust-bcc git:(cflags-support) ✗ sudo target/debug/examples/smoketest 
smoketest: empty table
smoketest: sized histogram
smoketest: hash insert and delete
smoketest: array
smoketest: cflags
smoketest passed
```


Thanks!
