### PR TITLE
add BPFBuilder with cflags support

### DIFF
--- a/examples/smoketest.rs
+++ b/examples/smoketest.rs
@@ -1,5 +1,5 @@
 use bcc::table::Entry;
-use bcc::BPF;
+use bcc::{BPFBuilder, BPF};
 
 fn main() {
     println!("smoketest: empty table");
@@ -49,6 +49,14 @@ fn main() {
     let entries: Vec<Entry> = table.iter().collect();
     assert_eq!(entries.get(1).unwrap().value, [0, 0, 0, 0, 0, 0, 13, 37]);
     assert_eq!(entries.get(0).unwrap().value, [0, 0, 0, 0, 0, 0, 0, 42]);
+
+    println!("smoketest: cflags");
+    assert!(BPFBuilder::new("int main() { return RETURN_CODE; }")
+        .unwrap()
+        .cflags(&["-DRETURN_CODE=0"])
+        .unwrap()
+        .build()
+        .is_ok());
 
     println!("smoketest passed");
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -112,9 +112,10 @@ impl BPFBuilder {
         let cflags = if self.cflags.is_empty() {
             ptr::null_mut()
         } else {
-            let mut cflags = self.cflags
+            let mut cflags = self
+                .cflags
                 .iter()
-                .map(|v| { std::mem::forget(v); v.as_ptr() })
+                .map(|v| v.as_ptr())
                 .collect::<Vec<*const c_char>>();
             let ptr = cflags.as_mut_ptr();
             std::mem::forget(cflags);
@@ -154,9 +155,10 @@ impl BPFBuilder {
         let cflags = if self.cflags.is_empty() {
             ptr::null_mut()
         } else {
-            let mut cflags = self.cflags
+            let mut cflags = self
+                .cflags
                 .iter()
-                .map(|v| { std::mem::forget(v); v.as_ptr() })
+                .map(|v| v.as_ptr())
                 .collect::<Vec<*const c_char>>();
             let ptr = cflags.as_mut_ptr();
             std::mem::forget(cflags);
@@ -204,9 +206,10 @@ impl BPFBuilder {
         let cflags = if self.cflags.is_empty() {
             ptr::null_mut()
         } else {
-            let mut cflags = self.cflags
+            let mut cflags = self
+                .cflags
                 .iter()
-                .map(|v| { std::mem::forget(v); v.as_ptr() })
+                .map(|v| v.as_ptr())
                 .collect::<Vec<*const c_char>>();
             let ptr = cflags.as_mut_ptr();
             std::mem::forget(cflags);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -53,7 +53,6 @@ pub struct BPF {
     pub(crate) perf_events_array: HashSet<PerfEventArray>,
     perf_readers: Vec<PerfReader>,
     sym_caches: HashMap<pid_t, SymbolCache>,
-    cflags: Vec<CString>,
 }
 
 // helper function that converts non-alphanumeric characters to underscores
@@ -113,11 +112,13 @@ impl BPFBuilder {
         let cflags = if self.cflags.is_empty() {
             ptr::null_mut()
         } else {
-            self.cflags
+            let mut cflags = self.cflags
                 .iter()
-                .map(|v| v.as_ptr())
-                .collect::<Vec<*const c_char>>()
-                .as_mut_ptr()
+                .map(|v| { std::mem::forget(v); v.as_ptr() })
+                .collect::<Vec<*const c_char>>();
+            let ptr = cflags.as_mut_ptr();
+            std::mem::forget(cflags);
+            ptr
         };
 
         let ptr = unsafe {
@@ -143,7 +144,6 @@ impl BPFBuilder {
             perf_events_array: HashSet::new(),
             perf_readers: Vec::new(),
             sym_caches: HashMap::new(),
-            cflags: self.cflags, // included to keep the pointers valid
         })
     }
 
@@ -154,11 +154,13 @@ impl BPFBuilder {
         let cflags = if self.cflags.is_empty() {
             ptr::null_mut()
         } else {
-            self.cflags
+            let mut cflags = self.cflags
                 .iter()
-                .map(|v| v.as_ptr())
-                .collect::<Vec<*const c_char>>()
-                .as_mut_ptr()
+                .map(|v| { std::mem::forget(v); v.as_ptr() })
+                .collect::<Vec<*const c_char>>();
+            let ptr = cflags.as_mut_ptr();
+            std::mem::forget(cflags);
+            ptr
         };
 
         let ptr = unsafe {
@@ -185,7 +187,6 @@ impl BPFBuilder {
             perf_events_array: HashSet::new(),
             perf_readers: Vec::new(),
             sym_caches: HashMap::new(),
-            cflags: self.cflags, // included to keep the pointers valid
         })
     }
 
@@ -203,11 +204,13 @@ impl BPFBuilder {
         let cflags = if self.cflags.is_empty() {
             ptr::null_mut()
         } else {
-            self.cflags
+            let mut cflags = self.cflags
                 .iter()
-                .map(|v| v.as_ptr())
-                .collect::<Vec<*const c_char>>()
-                .as_mut_ptr()
+                .map(|v| { std::mem::forget(v); v.as_ptr() })
+                .collect::<Vec<*const c_char>>();
+            let ptr = cflags.as_mut_ptr();
+            std::mem::forget(cflags);
+            ptr
         };
 
         let ptr = unsafe {
@@ -235,7 +238,6 @@ impl BPFBuilder {
             perf_events_array: HashSet::new(),
             perf_readers: Vec::new(),
             sym_caches: HashMap::new(),
-            cflags: self.cflags, // included to keep the pointers valid
         })
     }
 }
@@ -267,7 +269,6 @@ impl BPF {
             perf_events_array: HashSet::new(),
             perf_readers: Vec::new(),
             sym_caches: HashMap::new(),
-            cflags: Vec::new(),
         })
     }
 
@@ -292,7 +293,6 @@ impl BPF {
             perf_events_array: HashSet::new(),
             perf_readers: Vec::new(),
             sym_caches: HashMap::new(),
-            cflags: Vec::new(),
         })
     }
 
@@ -332,7 +332,6 @@ impl BPF {
             perf_events_array: HashSet::new(),
             perf_readers: Vec::new(),
             sym_caches: HashMap::new(),
-            cflags: Vec::new(),
         })
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -21,9 +21,11 @@ use crate::BccError;
 use core::ffi::c_void;
 use core::sync::atomic::{AtomicPtr, Ordering};
 use std::collections::{HashMap, HashSet};
+use std::convert::TryInto;
 use std::ffi::CString;
 use std::fs::File;
 use std::ops::Drop;
+use std::os::raw::c_char;
 use std::os::unix::prelude::*;
 use std::ptr;
 
@@ -51,6 +53,7 @@ pub struct BPF {
     pub(crate) perf_events_array: HashSet<PerfEventArray>,
     perf_readers: Vec<PerfReader>,
     sym_caches: HashMap<pid_t, SymbolCache>,
+    cflags: Vec<CString>,
 }
 
 // helper function that converts non-alphanumeric characters to underscores
@@ -67,6 +70,173 @@ fn null_or_mut_ptr<T>(s: &mut Vec<u8>) -> *mut T {
         ptr::null_mut()
     } else {
         s.as_mut_ptr() as *mut T
+    }
+}
+
+/// A builder struct which allows one to initialize a BPF module with additional
+/// options.
+pub struct BPFBuilder {
+    code: CString,
+    cflags: Vec<CString>,
+}
+
+impl BPFBuilder {
+    /// Create a new builder with the given code
+    pub fn new(code: &str) -> Result<Self, BccError> {
+        let code = CString::new(code)?;
+        Ok(Self {
+            code,
+            cflags: Vec::new(),
+        })
+    }
+
+    /// Set CFLAGS to be used
+    pub fn cflags<T: AsRef<str>>(mut self, cflags: &[T]) -> Result<Self, BccError> {
+        self.cflags.clear();
+        for f in cflags {
+            let cs = CString::new(f.as_ref())?;
+            self.cflags.push(cs);
+        }
+        Ok(self)
+    }
+
+    #[cfg(any(
+        feature = "v0_4_0",
+        feature = "v0_5_0",
+        feature = "v0_6_0",
+        feature = "v0_6_1",
+        feature = "v0_7_0",
+        feature = "v0_8_0",
+    ))]
+    /// Try constructing a BPF module from the builder
+    pub fn build(self) -> Result<BPF, BccError> {
+        let cflags = if self.cflags.is_empty() {
+            ptr::null_mut()
+        } else {
+            self.cflags
+                .iter()
+                .map(|v| v.as_ptr())
+                .collect::<Vec<*const c_char>>()
+                .as_mut_ptr()
+        };
+
+        let ptr = unsafe {
+            bpf_module_create_c_from_string(
+                self.code.as_ptr(),
+                2,
+                cflags,
+                self.cflags.len().try_into().unwrap(),
+            )
+        };
+
+        if ptr.is_null() {
+            return Err(BccError::Compilation);
+        }
+
+        Ok(BPF {
+            p: AtomicPtr::new(ptr),
+            uprobes: HashSet::new(),
+            kprobes: HashSet::new(),
+            tracepoints: HashSet::new(),
+            raw_tracepoints: HashSet::new(),
+            perf_events: HashSet::new(),
+            perf_events_array: HashSet::new(),
+            perf_readers: Vec::new(),
+            sym_caches: HashMap::new(),
+            cflags: self.cflags, // included to keep the pointers valid
+        })
+    }
+
+    // 0.9.0 changes the API for bpf_module_create_c_from_string()
+    #[cfg(any(feature = "v0_9_0", feature = "v0_10_0"))]
+    /// Try constructing a BPF module from the builder
+    pub fn build(self) -> Result<BPF, BccError> {
+        let cflags = if self.cflags.is_empty() {
+            ptr::null_mut()
+        } else {
+            self.cflags
+                .iter()
+                .map(|v| v.as_ptr())
+                .collect::<Vec<*const c_char>>()
+                .as_mut_ptr()
+        };
+
+        let ptr = unsafe {
+            bpf_module_create_c_from_string(
+                self.code.as_ptr(),
+                2,
+                cflags,
+                self.cflags.len().try_into().unwrap(),
+                true,
+            )
+        };
+
+        if ptr.is_null() {
+            return Err(BccError::Compilation);
+        }
+
+        Ok(BPF {
+            p: AtomicPtr::new(ptr),
+            uprobes: HashSet::new(),
+            kprobes: HashSet::new(),
+            tracepoints: HashSet::new(),
+            raw_tracepoints: HashSet::new(),
+            perf_events: HashSet::new(),
+            perf_events_array: HashSet::new(),
+            perf_readers: Vec::new(),
+            sym_caches: HashMap::new(),
+            cflags: self.cflags, // included to keep the pointers valid
+        })
+    }
+
+    // 0.11.0 changes the API for bpf_module_create_c_from_string()
+    #[cfg(any(
+        feature = "v0_11_0",
+        feature = "v0_12_0",
+        feature = "v0_13_0",
+        feature = "v0_14_0",
+        feature = "v0_15_0",
+        not(feature = "specific"),
+    ))]
+    /// Try constructing a BPF module from the builder
+    pub fn build(self) -> Result<BPF, BccError> {
+        let cflags = if self.cflags.is_empty() {
+            ptr::null_mut()
+        } else {
+            self.cflags
+                .iter()
+                .map(|v| v.as_ptr())
+                .collect::<Vec<*const c_char>>()
+                .as_mut_ptr()
+        };
+
+        let ptr = unsafe {
+            bpf_module_create_c_from_string(
+                self.code.as_ptr(),
+                2,
+                cflags,
+                self.cflags.len().try_into().unwrap(),
+                true,
+                ptr::null_mut(),
+            )
+        };
+
+        if ptr.is_null() {
+            return Err(BccError::Compilation);
+        }
+
+        Ok(BPF {
+            p: AtomicPtr::new(ptr),
+            uprobes: HashSet::new(),
+            kprobes: HashSet::new(),
+            tracepoints: HashSet::new(),
+            raw_tracepoints: HashSet::new(),
+            perf_events: HashSet::new(),
+            perf_events_array: HashSet::new(),
+            perf_readers: Vec::new(),
+            sym_caches: HashMap::new(),
+            cflags: self.cflags, // included to keep the pointers valid
+        })
     }
 }
 
@@ -97,6 +267,7 @@ impl BPF {
             perf_events_array: HashSet::new(),
             perf_readers: Vec::new(),
             sym_caches: HashMap::new(),
+            cflags: Vec::new(),
         })
     }
 
@@ -121,6 +292,7 @@ impl BPF {
             perf_events_array: HashSet::new(),
             perf_readers: Vec::new(),
             sym_caches: HashMap::new(),
+            cflags: Vec::new(),
         })
     }
 
@@ -160,6 +332,7 @@ impl BPF {
             perf_events_array: HashSet::new(),
             perf_readers: Vec::new(),
             sym_caches: HashMap::new(),
+            cflags: Vec::new(),
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod tracepoint;
 mod types;
 mod uprobe;
 
-pub use crate::core::BPF;
+pub use crate::core::{BPFBuilder, BPF};
 pub use error::BccError;
 pub use kprobe::{Kprobe, Kretprobe};
 pub use perf_event::{PerfEvent, PerfEventArray, PerfMap};

--- a/src/perf_event/mod.rs
+++ b/src/perf_event/mod.rs
@@ -1,5 +1,6 @@
 mod callback;
 mod events;
+#[allow(clippy::module_inception)]
 mod perf_event;
 mod perf_event_array;
 mod perf_map;


### PR DESCRIPTION
Adds a builder pattern for instantiating a new BPF module with
support for cflags.

Provides functionality to match intent of #127 with a more
idiomatic pattern for construction.

Non-breaking change, users can migrate to the new pattern
if required. We may consider deprecating the original
constructor eventually, but for now it is left as-is.