### PR TITLE
add PerfMapBuilder

### DIFF
--- a/src/perf_event/mod.rs
+++ b/src/perf_event/mod.rs
@@ -26,6 +26,7 @@ const BPF_PERF_READER_PAGE_CNT: i32 = 64;
 fn open_perf_buffer(
     cpu: usize,
     raw_cb: Box<dyn FnMut(&[u8]) + Send>,
+    page_count: i32,
 ) -> Result<PerfReader, BccError> {
     let callback = Box::new(PerfCallback::new(raw_cb));
     let reader = unsafe {
@@ -35,7 +36,7 @@ fn open_perf_buffer(
             Box::into_raw(callback) as MutPointer,
             -1, /* pid */
             cpu as i32,
-            BPF_PERF_READER_PAGE_CNT,
+            page_count,
         )
     };
     if reader.is_null() {

--- a/src/perf_event/perf_map.rs
+++ b/src/perf_event/perf_map.rs
@@ -9,42 +9,73 @@ use byteorder::NativeEndian;
 use byteorder::WriteBytesExt;
 use std::io::Cursor;
 
+/// A builder type for producing `PerfMap`s
+pub struct PerfMapBuilder<F: Fn() -> Box<dyn FnMut(&[u8]) + Send>> {
+    table: Table,
+    cb: F,
+    page_count: i32,
+}
+
+impl<F: Fn() -> Box<dyn FnMut(&[u8]) + Send>> PerfMapBuilder<F> {
+    /// Create a new builder for a given table and callback function
+    pub fn new(table: Table, cb: F) -> Self {
+        Self {
+            table,
+            cb,
+            page_count: super::BPF_PERF_READER_PAGE_CNT,
+        }
+    }
+
+    /// Set the page count for the ringbuffer
+    pub fn page_count(mut self, page_count: i32) -> Self {
+        self.page_count = page_count;
+        self
+    }
+
+    /// Try constructing a `PerfMap` from the builder
+    pub fn build(mut self) -> Result<PerfMap, BccError> {
+        let key_size = self.table.key_size();
+        let leaf_size = self.table.leaf_size();
+        let leaf = vec![0; leaf_size];
+
+        if key_size != 4 || leaf_size != 4 {
+            return Err(BccError::TableInvalidSize);
+        }
+
+        let mut readers: Vec<PerfReader> = vec![];
+        let mut cur = Cursor::new(leaf);
+
+        let cpus = cpuonline::get()?;
+        for cpu in cpus.iter() {
+            let mut reader = open_perf_buffer(*cpu, (self.cb)(), self.page_count)?;
+            let perf_fd = reader.fd() as u32;
+            readers.push(reader);
+
+            let mut key = vec![];
+            key.write_u32::<NativeEndian>(*cpu as u32)?;
+            cur.write_u32::<NativeEndian>(perf_fd)?;
+            if self.table.set(&mut key, &mut cur.get_mut()).is_ok() {
+                cur.set_position(0);
+            } else {
+                return Err(BccError::InitializePerfMap);
+            }
+        }
+        Ok(PerfMap { readers })
+    }
+}
+
 #[allow(dead_code)]
 pub struct PerfMap {
     pub(crate) readers: Vec<PerfReader>,
 }
 
-pub fn init_perf_map<F>(mut table: Table, cb: F) -> Result<PerfMap, BccError>
+/// Convenience function to initialize a `PerfMap` without using the builder
+/// pattern. Will be deprecated in a future release.
+pub fn init_perf_map<F>(table: Table, cb: F) -> Result<PerfMap, BccError>
 where
     F: Fn() -> Box<dyn FnMut(&[u8]) + Send>,
 {
-    let key_size = table.key_size();
-    let leaf_size = table.leaf_size();
-    let leaf = vec![0; leaf_size];
-
-    if key_size != 4 || leaf_size != 4 {
-        return Err(BccError::TableInvalidSize);
-    }
-
-    let mut readers: Vec<PerfReader> = vec![];
-    let mut cur = Cursor::new(leaf);
-
-    let cpus = cpuonline::get()?;
-    for cpu in cpus.iter() {
-        let mut reader = open_perf_buffer(*cpu, cb())?;
-        let perf_fd = reader.fd() as u32;
-        readers.push(reader);
-
-        let mut key = vec![];
-        key.write_u32::<NativeEndian>(*cpu as u32)?;
-        cur.write_u32::<NativeEndian>(perf_fd)?;
-        if table.set(&mut key, &mut cur.get_mut()).is_ok() {
-            cur.set_position(0);
-        } else {
-            return Err(BccError::InitializePerfMap);
-        }
-    }
-    Ok(PerfMap { readers })
+    PerfMapBuilder::new(table, cb).build()
 }
 
 impl PerfMap {


### PR DESCRIPTION
Adds a builder pattern for constructing `PerfMap`s that allows for
a configurable page count for the ring buffer.

This would take the place of #74 