### PR TITLE
Use correct char type, permits building on aarch64

### DIFF
--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -8,6 +8,7 @@ use core::sync::atomic::{AtomicPtr, Ordering};
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::mem;
+use std::os::raw::c_char;
 use std::ptr;
 
 pub fn resolve_symbol_path(
@@ -51,7 +52,7 @@ pub fn resolve_symname(
         })
     } else {
         let module = unsafe {
-            CStr::from_ptr(symbol.module as *mut i8)
+            CStr::from_ptr(symbol.module as *mut c_char)
                 .to_str()?
                 .to_string()
         };


### PR DESCRIPTION
briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this
  change?)
  * I want to build for aarch64
* what changes does this pull request make?
  * Swaps out an `i8` for the correct `c_char` type.
* are there any non-obvious implications of these changes? (does it break compatibility with previous
  versions, etc)
  * No
