### PR TITLE
Run tests under Valgrind to detect memory issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 bcc-sys/src/bccapi.rs
 Cargo.lock
+*.swp

--- a/build/valgrind-suppressions.supp
+++ b/build/valgrind-suppressions.supp
@@ -1,0 +1,54 @@
+{
+   <supress_NULL_key_in_bpf_syscall_attr>
+   Memcheck:Param
+   bpf(attr->key)
+   fun:syscall
+   ...
+   fun:bpf_get_first_key
+   ...
+}
+
+{
+   <clang_if_parser>
+   Memcheck:Cond
+   fun:_ZN5clang6Parser16ParseIfStatementEPNS_14SourceLocationE
+   ...
+}
+
+
+{
+   <specific_llvm_dwarf_range_span>
+   Memcheck:Cond
+   fun:_ZN4llvm16DwarfCompileUnit8addRangeENS_9RangeSpanE
+   fun:_ZN4llvm10DwarfDebug15endFunctionImplEPKNS_15MachineFunctionE
+   fun:_ZN4llvm16DebugHandlerBase11endFunctionEPKNS_15MachineFunctionE
+   fun:_ZN4llvm10AsmPrinter16EmitFunctionBodyEv
+   fun:_ZN4llvm10AsmPrinter20runOnMachineFunctionERNS_15MachineFunctionE
+   fun:_ZN4llvm19MachineFunctionPass13runOnFunctionERNS_8FunctionE
+   fun:_ZN4llvm13FPPassManager13runOnFunctionERNS_8FunctionE
+   fun:_ZN4llvm13FPPassManager11runOnModuleERNS_6ModuleE
+   fun:runOnModule
+   fun:_ZN4llvm6legacy15PassManagerImpl3runERNS_6ModuleE
+   fun:_ZN4llvm5MCJIT10emitObjectEPNS_6ModuleE
+   fun:_ZN4llvm5MCJIT21generateCodeForModuleEPNS_6ModuleE
+   fun:_ZN4llvm5MCJIT14finalizeObjectEv
+}
+
+
+{
+   <ebpf_clang_probe_visitor_assigns_ext_otr>
+   Memcheck:Cond
+   fun:_ZN4ebpf12ProbeVisitor12VisitVarDeclEPN5clang7VarDeclE
+   fun:_ZN5clang19RecursiveASTVisitorIN4ebpf12ProbeVisitorEE12TraverseDeclEPNS_4DeclE
+   fun:_ZN5clang19RecursiveASTVisitorIN4ebpf12ProbeVisitorEE16dataTraverseNodeEPNS_4StmtEPN4llvm15SmallVectorImplINS6_14PointerIntPairIS5_Lj1EbNS6_21PointerLikeTypeTraitsIS5_EENS6_18PointerIntPairInfoIS5_Lj1ESA_EEEEEE
+   fun:_ZN4ebpf12ProbeVisitor12TraverseStmtEPN5clang4StmtE
+   ...
+}
+
+{
+   <ebpf_clang_probe_visitor_visit_var_decl>
+   Memcheck:Cond
+   fun:_ZN4ebpf12ProbeVisitor13assignsExtPtrEPN5clang4ExprEPi
+   fun:_ZN4ebpf12ProbeVisitor12VisitVarDeclEPN5clang7VarDeclE
+   ...
+}


### PR DESCRIPTION
Adding Valgrind could help us detect memory leaks and memory unsafety. Assuming Valgrind is installed, it can be run with:

```
$ cargo build --example smoketest
$ valgrind --version
valgrind-3.15.0
$ sudo valgrind --suppressions=build/valgrind-suppressions.supp target/debug/examples/smoketest     
```

This currently suppress the error below, to make it easier to detect new issues that are introduced. I am unsure if it's a false positive, will try to investigate later
```
[...]
smoketest: empty table
==22911== Syscall param bpf(attr->key) points to unaddressable byte(s)
==22911==    at 0x6E84DDD: syscall (in /usr/lib64/libc-2.29.so)
==22911==    by 0x64CA8D0: bpf_map_get_next_key (in /usr/lib64/libbcc.so.0.12.0)
==22911==    by 0x64C7E03: bpf_get_first_key (in /usr/lib64/libbcc.so.0.12.0)
==22911==    by 0x11A5D2: bcc::table::EntryIter::start (table.rs:160)
==22911==    by 0x11A770: <bcc::table::EntryIter as core::iter::traits::iterator::Iterator>::next (dfa.rs:685)
==22911==    by 0x115AC1: find_at (vec.rs:2076)
==22911==    by 0x115AC1: find_at (exec.rs:590)
==22911==    by 0x115AC1: <alloc::vec::Vec<T> as alloc::vec::SpecExtend<T,I>>::from_iter (re_bytes.rs:593)
==22911==    by 0x115E5A: find_at (dfa.rs:0)
==22911==    by 0x115E5A: find_at (exec.rs:590)
==22911==    by 0x115E5A: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter (re_bytes.rs:593)
==22911==    by 0x114099: find_at (iterator.rs:1671)
==22911==    by 0x114099: find_at (exec.rs:590)
==22911==    by 0x114099: core::iter::traits::iterator::Iterator::collect (re_bytes.rs:593)
==22911==    by 0x111E43: find_at (dfa.rs:0)
==22911==    by 0x111E43: find_at (exec.rs:590)
==22911==    by 0x111E43: smoketest::main (re_bytes.rs:593)
==22911==    by 0x114CCA: find_at (dfa.rs:785)
==22911==    by 0x114CCA: find_at (exec.rs:590)
==22911==    by 0x114CCA: std::rt::lang_start::{{closure}} (re_bytes.rs:593)
==22911==    by 0x13A077: {{closure}} (rt.rs:52)
==22911==    by 0x13A077: do_call<closure-0,i32> (panicking.rs:297)
==22911==    by 0x13A077: try<i32,closure-0> (panicking.rs:274)
==22911==    by 0x13A077: catch_unwind<closure-0,i32> (panic.rs:394)
==22911==    by 0x13A077: std::rt::lang_start_internal (rt.rs:51)
==22911==    by 0x114CA6: find_at (dfa.rs:875)
==22911==    by 0x114CA6: find_at (exec.rs:590)
==22911==    by 0x114CA6: std::rt::lang_start (re_bytes.rs:593)
==22911==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==22911== 
[...]
```

Should we add this in each action job or have one specific job with a LLVM and BCC version (i.e. the newer one that is supported) that runs Valgrind on the smoke tests and potentially some of the tools?

Thanks!
