### PR TITLE
Add gethostlatency example

### DIFF
--- a/examples/biosnoop.c
+++ b/examples/biosnoop.c
@@ -1,7 +1,7 @@
 #include <uapi/linux/ptrace.h>
 #include <linux/blkdev.h>
 
-// This code is taken from: https://github.com/iovisor/bcc/tools/biosnoop.py
+// This code is taken from: https://github.com/iovisor/bcc/blob/master/tools/biosnoop.py
 //
 // Copyright (c) 2015 Brendan Gregg.
 // Licensed under the Apache License, Version 2.0 (the "License")

--- a/examples/gethostlatency.c
+++ b/examples/gethostlatency.c
@@ -1,0 +1,47 @@
+#include <uapi/linux/ptrace.h>
+#include <linux/sched.h>
+struct start_timestamp_t {
+    u32 pid;
+    char comm[TASK_COMM_LEN];
+    char host[80];
+    u64 ts;
+};
+struct latency_event_t {
+    u32 pid;
+    u64 delta;
+    char comm[TASK_COMM_LEN];
+    char host[80];
+};
+BPF_HASH(start, u32, struct start_timestamp_t);
+BPF_PERF_OUTPUT(events);
+int do_entry(struct pt_regs *ctx) {
+    if (!PT_REGS_PARM1(ctx))
+        return 0;
+    struct start_timestamp_t val = {};
+    u32 pid = bpf_get_current_pid_tgid();
+    if (bpf_get_current_comm(&val.comm, sizeof(val.comm)) == 0) {
+        bpf_probe_read_user(&val.host, sizeof(val.host),
+                       (void *)PT_REGS_PARM1(ctx));
+        val.pid = bpf_get_current_pid_tgid();
+        val.ts = bpf_ktime_get_ns();
+        start.update(&pid, &val);
+    }
+    return 0;
+}
+int do_return(struct pt_regs *ctx) {
+    struct start_timestamp_t *start_timestamp;
+    struct latency_event_t perf_event = {};
+    u64 delta;
+    u32 pid = bpf_get_current_pid_tgid();
+    u64 finish_timestamp = bpf_ktime_get_ns();
+    start_timestamp = start.lookup(&pid);
+    if (start_timestamp == 0)
+        return 0; // missed start
+    bpf_probe_read_kernel(&perf_event.comm, sizeof(perf_event.comm), start_timestamp->comm);
+    bpf_probe_read_kernel(&perf_event.host, sizeof(perf_event.host), (void *)start_timestamp->host);
+    perf_event.pid = start_timestamp->pid;
+    perf_event.delta = finish_timestamp - start_timestamp->ts;
+    events.perf_submit(ctx, &perf_event, sizeof(perf_event));
+    start.delete(&pid);
+    return 0;
+}

--- a/examples/gethostlatency.c
+++ b/examples/gethostlatency.c
@@ -1,5 +1,11 @@
 #include <uapi/linux/ptrace.h>
 #include <linux/sched.h>
+
+// This code is taken from: https://github.com/iovisor/bcc/blob/master/tools/gethostlatency.py
+//
+// Copyright 2016 Netflix, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License")
+
 struct start_timestamp_t {
     u32 pid;
     char comm[TASK_COMM_LEN];

--- a/examples/gethostlatency.c
+++ b/examples/gethostlatency.c
@@ -12,14 +12,17 @@ struct start_timestamp_t {
     char host[80];
     u64 ts;
 };
+
 struct latency_event_t {
     u32 pid;
     u64 delta;
     char comm[TASK_COMM_LEN];
     char host[80];
 };
+
 BPF_HASH(start, u32, struct start_timestamp_t);
 BPF_PERF_OUTPUT(events);
+
 int do_entry(struct pt_regs *ctx) {
     if (!PT_REGS_PARM1(ctx))
         return 0;
@@ -34,6 +37,7 @@ int do_entry(struct pt_regs *ctx) {
     }
     return 0;
 }
+
 int do_return(struct pt_regs *ctx) {
     struct start_timestamp_t *start_timestamp;
     struct latency_event_t perf_event = {};

--- a/examples/gethostlatency.rs
+++ b/examples/gethostlatency.rs
@@ -1,4 +1,4 @@
-use bcc::perf_event::init_perf_map;
+use bcc::perf_event::PerfMapBuilder;
 use bcc::BccError;
 use bcc::{Uprobe, Uretprobe, BPF};
 use clap::{App, Arg};
@@ -80,7 +80,7 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     // the "events" table is where the "function was called" events get sent
     let table = module.table("events")?;
     // install a callback to print out latency events when they happen
-    let mut perf_map = init_perf_map(table, perf_data_callback)?;
+    let mut perf_map = PerfMapBuilder::new(table, perf_data_callback).build()?;
     // print a header
     println!(
         "{:<9} {:<6} {:<16} {:>10} {}",

--- a/examples/gethostlatency.rs
+++ b/examples/gethostlatency.rs
@@ -1,0 +1,128 @@
+use bcc::perf_event::init_perf_map;
+use bcc::BccError;
+use bcc::{Uprobe, Uretprobe, BPF};
+use clap::{App, Arg};
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::{fmt, ptr};
+
+/*
+ * Basic Rust clone of `gethostlatency`, from the iovisor tools.
+ * https://github.com/iovisor/bcc/blob/master/tools/gethostlatency.py
+ *
+ * Prints the latency for getaddrinfo/gethostbyname(3) calls, which are a common part of DNS lookups.
+ */
+
+/*
+ * Define the struct the BPF code writes in Rust
+ * This must match the struct in `gethostlatency.c` exactly.
+ * The important thing to understand about the code in `gethostlatency.c` is that it creates structs of
+ * type `latency_event_t` and pushes them into a buffer where our Rust code can read them.
+ */
+#[repr(C)]
+struct latency_event_t {
+    pid: u32,
+    delta: u64,
+    comm: [u8; 16], // TASK_COMM_LEN
+    host: [u8; 80],
+}
+
+impl fmt::Display for latency_event_t {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{:<9} {:<6} {:<16} {:>10.2} {}",
+            chrono::Utc::now().format("%T"),
+            self.pid,
+            get_string(&self.comm),
+            (self.delta as f32) / 1e6,
+            get_string(&self.host)
+        )
+    }
+}
+
+fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
+    let matches = App::new("gethostlatency")
+        .about("Prints the latency for getaddrinfo/gethostbyname(2) calls")
+        .arg(
+            Arg::with_name("pid")
+                .long("pid")
+                .short("p")
+                .help("Only trace calls from this PID")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let pid: Option<i32> = matches
+        .value_of("pid")
+        .map(|v| v.parse::<i32>().expect("Invalid argument for PID"));
+
+    // attach entry and return probes for common host lookup functions
+    let libc_so_path = "/lib/x86_64-linux-gnu/libc.so.6";
+    let code = include_str!("gethostlatency.c");
+    let mut module = BPF::new(code)?;
+    for symbol in vec!["getaddrinfo", "gethostbyname", "gethostbyname2"] {
+        Uprobe::new()
+            .handler("do_entry")
+            .binary(libc_so_path)
+            .symbol(symbol)
+            .pid(pid)
+            .attach(&mut module)?;
+        Uretprobe::new()
+            .handler("do_return")
+            .binary(libc_so_path)
+            .symbol(symbol)
+            .pid(pid)
+            .attach(&mut module)?;
+    }
+
+    // the "events" table is where the "function was called" events get sent
+    let table = module.table("events")?;
+    // install a callback to print out latency events when they happen
+    let mut perf_map = init_perf_map(table, perf_data_callback)?;
+    // print a header
+    println!(
+        "{:<9} {:<6} {:<16} {:>10} {}",
+        "TIME", "PID", "COMM", "LATms", "HOST"
+    );
+    // this `.poll()` loop is what makes our callback get called
+    while runnable.load(Ordering::SeqCst) {
+        perf_map.poll(200);
+    }
+    Ok(())
+}
+
+fn perf_data_callback() -> Box<dyn FnMut(&[u8]) + Send> {
+    Box::new(|x| {
+        println!("{}", parse_struct(x));
+    })
+}
+
+fn parse_struct(x: &[u8]) -> latency_event_t {
+    unsafe { ptr::read(x.as_ptr() as *const latency_event_t) }
+}
+
+fn get_string(x: &[u8]) -> String {
+    match x.iter().position(|&r| r == 0) {
+        Some(zero_pos) => String::from_utf8_lossy(&x[0..zero_pos]).to_string(),
+        None => String::from_utf8_lossy(x).to_string(),
+    }
+}
+
+fn main() {
+    let runnable = Arc::new(AtomicBool::new(true));
+    let r = runnable.clone();
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    })
+    .expect("Failed to set handler for SIGINT / SIGTERM");
+
+    match do_main(runnable) {
+        Err(x) => {
+            eprintln!("Error: {}", x);
+            std::process::exit(1);
+        }
+        _ => {}
+    }
+}

--- a/examples/softirqs_0_4_0.c
+++ b/examples/softirqs_0_4_0.c
@@ -1,6 +1,6 @@
 #include <uapi/linux/ptrace.h>
 
-// This code is taken from: https://github.com/iovisor/bcc/tools/softirqs.py
+// This code is taken from: https://github.com/iovisor/bcc/blob/master/tools/softirqs.py
 //
 // Copyright (c) 2015 Brendan Gregg.
 // Licensed under the Apache License, Version 2.0 (the "License")

--- a/examples/softirqs_0_7_0.c
+++ b/examples/softirqs_0_7_0.c
@@ -1,6 +1,6 @@
 #include <uapi/linux/ptrace.h>
 
-// This code is taken from: https://github.com/iovisor/bcc/tools/softirqs.py
+// This code is taken from: https://github.com/iovisor/bcc/blob/master/tools/softirqs.py
 //
 // Copyright (c) 2015 Brendan Gregg.
 // Licensed under the Apache License, Version 2.0 (the "License")

--- a/src/uprobe/mod.rs
+++ b/src/uprobe/mod.rs
@@ -84,7 +84,7 @@ impl Uprobe {
 
         let (path, addr) = crate::symbol::resolve_symbol_path(&binary, &symbol, 0x0, pid)?;
         let alpha_path = make_alphanumeric(&path);
-        let ev_name = format!("r_{}_0x{:x}", &alpha_path, addr);
+        let ev_name = format!("p_{}_0x{:x}", &alpha_path, addr);
 
         let code_fd = bpf.load(&handler, BPF_PROG_TYPE_KPROBE, 0, 0)?;
 


### PR DESCRIPTION
* what problem are you trying to solve? (or if there's no problem, what's the motivation for this
  change?)
  * Make it possible to use uprobes and uretprobes for the same symbol
* what changes does this pull request make?
  * Fix hash key collisions so that uprobes and uretprobes for the same symbol can be used in the same program. I followed the same `p_` and `r_` convention that kprobes use
  * Add example of using uprobes and uretprobes together (gethostlatency)
* are there any non-obvious implications of these changes? (does it break compatibility with previous
  versions, etc)
  * I don't think so
