### PR TITLE
Add load_func support and allow setting the debug level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ byteorder = "1.3.4"
 libc = "0.2.68"
 regex = "1.3.5"
 thiserror = "1.0.19"
+bitflags = "*"
 
 [dev-dependencies]
 clap = "2.33.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ byteorder = "1.3.4"
 libc = "0.2.68"
 regex = "1.3.5"
 thiserror = "1.0.19"
-bitflags = "*"
+bitflags = "1.2.1"
 
 [dev-dependencies]
 clap = "2.33.0"

--- a/examples/smoketest.rs
+++ b/examples/smoketest.rs
@@ -70,5 +70,13 @@ fn main() {
         .build()
         .is_ok());
 
+    println!("smoketest: debug level");
+    assert!(BPFBuilder::new("")
+        .unwrap()
+        .debug(Default::default())
+        .unwrap()
+        .build()
+        .is_ok());
+
     println!("smoketest passed");
 }

--- a/examples/smoketest.rs
+++ b/examples/smoketest.rs
@@ -1,5 +1,6 @@
+use bcc::perf_event::{Event, SoftwareEvent};
 use bcc::table::Entry;
-use bcc::{BPFBuilder, BPF};
+use bcc::{BPFBuilder, BpfProgType, PerfEvent, BPF};
 
 fn main() {
     println!("smoketest: empty table");
@@ -78,5 +79,92 @@ fn main() {
         .build()
         .is_ok());
 
+    println!("smoketest: tail calls");
+    run_tail_calls();
+
     println!("smoketest passed");
+}
+#[cfg(any(
+    feature = "v0_6_0",
+    feature = "v0_6_1",
+    feature = "v0_7_0",
+    feature = "v0_8_0",
+))]
+fn run_tail_calls() {
+    let mut bpf = BPFBuilder::new(
+        "#include <uapi/linux/bpf_perf_event.h>
+        BPF_PROG_ARRAY(programs, 1);
+
+        int my_func(struct bpf_perf_event_data *ctx) {
+            return 0;
+        }
+        int on_event(struct bpf_perf_event_data *ctx){
+            programs.call(ctx, 0);
+            return 0;
+        }",
+    )
+    .unwrap()
+    .build()
+    .unwrap();
+
+    PerfEvent::new()
+        .handler("on_event")
+        .event(Event::Software(SoftwareEvent::CpuClock))
+        .sample_frequency(Some(99))
+        .attach(&mut bpf)
+        .unwrap();
+
+    let mut table = bpf.table("programs").unwrap();
+    let mut index = 0_u32.to_ne_bytes();
+
+    assert!(bpf.load_func("my_func", BpfProgType::PerfEvent).is_err())
+}
+
+#[cfg(any(
+    feature = "v0_9_0",
+    feature = "v0_10_0",
+    feature = "v0_11_0",
+    feature = "v0_12_0",
+    feature = "v0_13_0",
+    feature = "v0_14_0",
+    feature = "v0_15_0",
+    feature = "v0_16_0",
+    not(feature = "specific"),
+))]
+fn run_tail_calls() {
+    let mut bpf = BPFBuilder::new(
+        "#include <uapi/linux/bpf_perf_event.h>
+        BPF_PROG_ARRAY(programs, 1);
+
+        int my_func(struct bpf_perf_event_data *ctx) {
+            return 0;
+        }
+        int on_event(struct bpf_perf_event_data *ctx){
+            programs.call(ctx, 0);
+            return 0;
+        }",
+    )
+    .unwrap()
+    .build()
+    .unwrap();
+
+    PerfEvent::new()
+        .handler("on_event")
+        .event(Event::Software(SoftwareEvent::CpuClock))
+        .sample_frequency(Some(99))
+        .attach(&mut bpf)
+        .unwrap();
+
+    let mut table = bpf.table("programs").unwrap();
+    let mut index = 0_u32.to_ne_bytes();
+    let fd = bpf.load_func("my_func", BpfProgType::PerfEvent).unwrap();
+    let fd2 = bpf.load_func("my_func", BpfProgType::PerfEvent).unwrap();
+    assert_eq!(
+        fd, fd2,
+        "loading the same function more than once should return the same fd"
+    );
+    table.set(&mut index, &mut fd.to_ne_bytes()).unwrap();
+    assert!(bpf
+        .load_func("non_existent_func", BpfProgType::PerfEvent)
+        .is_err());
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,7 +37,7 @@ pub enum BccError {
     InitializePerfMap,
     #[error("invalid cpu range ({range})")]
     InvalidCpuRange { range: String },
-    #[error("error loading bpf probe ({name}): {message}")]
+    #[error("error loading bpf program ({name}): {message}")]
     Loading { name: String, message: String },
     #[error("null string")]
     NullString(#[from] std::ffi::NulError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ mod uprobe;
 #[macro_use]
 extern crate bitflags;
 
-pub use crate::core::{BPFBuilder, BPF};
+pub use crate::core::{BPFBuilder, BpfProgType, BPF};
 pub use error::BccError;
 pub use kprobe::{Kprobe, Kretprobe};
 pub use perf_event::{PerfEvent, PerfEventArray, PerfMap};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@ mod tracepoint;
 mod types;
 mod uprobe;
 
+#[macro_use]
+extern crate bitflags;
+
 pub use crate::core::{BPFBuilder, BPF};
 pub use error::BccError;
 pub use kprobe::{Kprobe, Kretprobe};


### PR DESCRIPTION
This PR adds support for loading BPF programs via `load_func`, which is used in BPF tail-calls programs. See the commits' messages for more context on this and when it is useful. It also adds support to select the very handy BCC debug level.

We add the `bitflags` crate to have a nicer way of dealing with the debug flags, and modify one of the error codes to be cleaner, and add expose `BpfProgType` in the crate's root.

We could migrate the current `log_level` and other calls that take a debug / log level, to the more type-safe `BccDebug` in another PR :smile: 

### Test plan
Added some more smoke tests for these new features, and ran them with Vagrind. Also tried this new feature in a project I am currently porting from a Python BCC driver.

