### PR TITLE
Pass debug flags to rest of BPF loading methods

### DIFF
--- a/examples/smoketest.rs
+++ b/examples/smoketest.rs
@@ -75,7 +75,6 @@ fn main() {
     assert!(BPFBuilder::new("")
         .unwrap()
         .debug(Default::default())
-        .unwrap()
         .build()
         .is_ok());
 
@@ -87,6 +86,7 @@ fn main() {
 
     println!("smoketest passed");
 }
+
 #[cfg(any(
     feature = "v0_6_0",
     feature = "v0_6_1",

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -137,9 +137,9 @@ impl BPFBuilder {
     }
 
     /// Set BCC's debug level
-    pub fn debug(mut self, debug: BccDebug) -> Result<Self, BccError> {
+    pub fn debug(mut self, debug: BccDebug) -> Self {
         self.debug = debug;
-        Ok(self)
+        self
     }
 
     #[cfg(any(
@@ -155,7 +155,7 @@ impl BPFBuilder {
         let ptr = unsafe {
             bpf_module_create_c_from_string(
                 self.code.as_ptr(),
-                2,
+                self.debug.bits(),
                 self.cflags
                     .iter()
                     .map(|v| v.as_ptr())
@@ -193,7 +193,7 @@ impl BPFBuilder {
         let ptr = unsafe {
             bpf_module_create_c_from_string(
                 self.code.as_ptr(),
-                2,
+                self.debug.bits(),
                 self.cflags
                     .iter()
                     .map(|v| v.as_ptr())
@@ -240,7 +240,7 @@ impl BPFBuilder {
         let ptr = unsafe {
             bpf_module_create_c_from_string(
                 self.code.as_ptr(),
-                2,
+                self.debug.bits(),
                 self.cflags
                     .iter()
                     .map(|v| v.as_ptr())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ mod xdp;
 #[macro_use]
 extern crate bitflags;
 
-pub use crate::core::{BPFBuilder, BpfProgType, BPF};
+pub use crate::core::{BPFBuilder, BccDebug, BpfProgType, BPF};
 pub use error::BccError;
 pub use kprobe::{Kprobe, Kretprobe};
 pub use perf_event::{PerfEvent, PerfEventArray, PerfMap};


### PR DESCRIPTION
Also:
- return `self` directly in the `debug` method, as it can't fail (sorry for the churn!)
- fix some small style issues