### PR TITLE
Get correct prefix for get_syscall_fnname

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -644,7 +644,7 @@ impl BPF {
     /// Returns the syscall prefix for the running kernel
     pub fn get_syscall_prefix(&mut self) -> String {
         for prefix in SYSCALL_PREFIXES.iter() {
-            if self.ksymname(prefix).is_ok() {
+            if self.ksymname(&format!("{}bpf", prefix)).is_ok() {
                 return (*prefix).to_string();
             }
         }


### PR DESCRIPTION
briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this
  change?)

get_syscall_fnname doesn't always return the correct prefixed function name for bpf tracing

(On my system, arch linux with kernel 5.9.1 I get sys_open instead of __x64_sys_open for example).

* what changes does this pull request make?

This PR changes get_syscall_prefix to look for the BPF syscall function name instead of just the function name.

* are there any non-obvious implications of these changes? (does it break compatibility with previous
  versions, etc)

I'm not sure why the implementation was different from the Python implementation in the first place.

PR #87 claims to be a port of the Python function but the bpf suffix was ommitted from the ksymname lookup. Compare:

https://github.com/iovisor/bcc/blob/master/src/python/bcc/__init__.py#L641 
