### PR TITLE
deprecate init_perf_map function

### DIFF
--- a/src/perf_event/perf_map.rs
+++ b/src/perf_event/perf_map.rs
@@ -71,6 +71,10 @@ pub struct PerfMap {
 
 /// Convenience function to initialize a `PerfMap` without using the builder
 /// pattern. Will be deprecated in a future release.
+#[deprecated(
+    since = "0.0.30",
+    note = "Please use PerfMapBuilder to create a new PerfMap instead"
+)]
 pub fn init_perf_map<F>(table: Table, cb: F) -> Result<PerfMap, BccError>
 where
     F: Fn() -> Box<dyn FnMut(&[u8]) + Send>,


### PR DESCRIPTION
Add deprecation to the init_perf_map function as per #142. We will
remove this function, not before 0.0.33 or at least 3 months from
the release of 0.0.30
