### PR TITLE
Updated biosnoop and opensnoop examples to use PerfMapBuilder

### DIFF
--- a/examples/biosnoop.rs
+++ b/examples/biosnoop.rs
@@ -1,4 +1,4 @@
-use bcc::perf_event::init_perf_map;
+use bcc::perf_event::PerfMapBuilder;
 use bcc::BccError;
 use bcc::{Kprobe, BPF};
 use clap::{App, Arg};
@@ -78,7 +78,7 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     }
     // the "events" table is where the "open file" events get sent
     let table = bpf.table("events")?;
-    let mut perf_map = init_perf_map(table, perf_data_callback)?;
+    let mut perf_map = PerfMapBuilder::new(table, perf_data_callback).build()?;
     // print a header
     println!(
         "{:<-11} {:<-14} {:<-6} {:<-7} {:<-1} {:<-10} {:>-7}",

--- a/examples/opensnoop.rs
+++ b/examples/opensnoop.rs
@@ -1,4 +1,4 @@
-use bcc::perf_event::init_perf_map;
+use bcc::perf_event::PerfMapBuilder;
 use bcc::BccError;
 use bcc::{Kprobe, Kretprobe, BPF};
 use clap::{App, Arg};
@@ -61,7 +61,7 @@ fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
     // the "events" table is where the "open file" events get sent
     let table = module.table("events")?;
     // install a callback to print out file open events when they happen
-    let mut perf_map = init_perf_map(table, perf_data_callback)?;
+    let mut perf_map = PerfMapBuilder::new(table, perf_data_callback).build()?;
     // print a header
     println!("{:-7} {:-16} {}", "PID", "COMM", "FILENAME");
     let start = std::time::Instant::now();


### PR DESCRIPTION
briefly answer these questions:

* **what problem are you trying to solve? (or if there's no problem, what's the motivation for this
  change?)**
To resolve #142 on some missing examples
* **what changes does this pull request make?**
It changes the biosnoop and opensnoop examples from using `init_perf_map` to using `PerfMapBuilder`
* **are there any non-obvious implications of these changes? (does it break compatibility with previous
  versions, etc)**
There should be none

## Testing
Ran both programs to confirm they still did what was expected and did not crash
