### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,18 @@ homepage = "https://github.com/rust-bpf/rust-bcc"
 edition = '2018'
 
 [dependencies]
-bcc-sys = "0.16.1"
+bcc-sys = "0.16.2"
 byteorder = "1.3.4"
-libc = "0.2.68"
-regex = "1.3.5"
-thiserror = "1.0.19"
+libc = "0.2.80"
+regex = "1.4.2"
+thiserror = "1.0.22"
 bitflags = "1.2.1"
 
 [dev-dependencies]
-clap = "2.33.0"
-ctrlc = "3.1.4"
+clap = "2.33.3"
+ctrlc = "3.1.7"
 lazy_static = "1.4.0"
-chrono = "0.4.11"
+chrono = "0.4.19"
 
 [features]
 llvm_8 = ["bcc-sys/llvm_8"]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use self::raw_tracepoint::RawTracepoint;
 pub(crate) use self::tracepoint::Tracepoint;
 pub(crate) use self::uprobe::Uprobe;
 pub(crate) use self::xdp::XDP;
-use crate::perf_event::PerfReader;
+use crate::perf_event::{PerfMapBuilder, PerfReader};
 use crate::symbol::SymbolCache;
 use crate::table::Table;
 use crate::BccError;
@@ -697,7 +697,7 @@ impl BPF {
     where
         F: Fn() -> Box<dyn FnMut(&[u8]) + Send>,
     {
-        let perf_map = crate::perf_event::init_perf_map(table, cb)?;
+        let perf_map = PerfMapBuilder::new(table, cb).build()?;
         self.perf_readers.extend(perf_map.readers);
         Ok(())
     }


### PR DESCRIPTION
Update dependencies to pull-in bugfixes and BPF ring buffer
support.

Fixes warning around deprecated function.
