### PR TITLE
Adds support for creating raw perf events

### DIFF
--- a/build/ci.sh
+++ b/build/ci.sh
@@ -6,11 +6,17 @@ set -e
 function test {
     runner="$1"
 
+    echo "smoketest"
     sudo $runner target/release/examples/smoketest
+    echo "runqlat"
     sudo $runner target/release/examples/runqlat --interval 1 --windows 5
+    echo "opensnoop"
     sudo $runner target/release/examples/opensnoop --duration 5
+    echo "biosnoop"
     sudo $runner target/release/examples/biosnoop --duration 5
+    echo "tcpretrans"
     sudo $runner target/release/examples/tcpretrans --duration 5
+    echo "contextswitch"
     sudo $runner target/release/examples/contextswitch --duration 5
 }
 

--- a/examples/memory.c
+++ b/examples/memory.c
@@ -1,0 +1,36 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+#include <linux/ptrace.h>
+#include <uapi/linux/bpf_perf_event.h>
+
+// Must provide the number of CPUs on the machine
+BPF_PERF_ARRAY(loads_perf, NUM_CPU);
+
+// Previously seen values
+BPF_ARRAY(loads_prev, u64, NUM_CPU);
+
+// Tables which are read in user space
+BPF_ARRAY(loads, u64, NUM_CPU);
+
+int do_count(struct bpf_perf_event_data *ctx) {
+    u32 cpu = bpf_get_smp_processor_id();
+
+    u64 loads_cnt = loads_perf.perf_read(CUR_CPU_IDENTIFIER);
+    if (((s64)loads_cnt < 0) && ((s64)loads_cnt > -256))
+        return 0;
+
+    u64* prev = loads_prev.lookup(&cpu);
+
+    u64 vLoads = 0;
+    if (prev) {
+        vLoads = loads_cnt - *prev;
+    }
+
+    loads_prev.update(&cpu, &loads_cnt);
+
+    loads.increment(cpu, vLoads);
+
+    return 0;
+}

--- a/examples/memory.rs
+++ b/examples/memory.rs
@@ -1,0 +1,145 @@
+// Copyright 2021 Twitter, Inc.
+// Licensed under the Apache License, Version 2.0
+// http://www.apache.org/licenses/LICENSE-2.0
+
+use bcc::perf_event::{Event, SoftwareEvent};
+use bcc::BccError;
+use bcc::{PerfEvent, PerfEventArray, BPF};
+use clap::{App, Arg};
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::{thread, time};
+
+// Both consants are arbitrary
+const DEFAULT_SAMPLE_FREQ: u64 = 99; // Hertz
+const DEFAULT_DURATION: u64 = 10; // Seconds
+
+#[cfg(any(
+    feature = "v0_4_0",
+    feature = "v0_5_0",
+    feature = "v0_6_0",
+    feature = "v0_6_1"
+))]
+fn do_main(_runnable: Arc<AtomicBool>) -> Result<(), BccError> {
+    panic!("requires bcc >= 0.7.0");
+}
+
+#[cfg(not(any(
+    feature = "v0_4_0",
+    feature = "v0_5_0",
+    feature = "v0_6_0",
+    feature = "v0_6_1"
+)))]
+fn do_main(runnable: Arc<AtomicBool>) -> Result<(), BccError> {
+    let matches = App::new("memory")
+        .arg(
+            Arg::with_name("duration")
+                .long("duration")
+                .short("d")
+                .help("How long to run this trace for (in seconds)")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let duration: u64 = matches
+        .value_of("duration")
+        .map(|v| v.parse().expect("Invalid duration"))
+        .unwrap_or(DEFAULT_DURATION);
+
+    let cpus = bcc::cpuonline::get()?.len() as u32;
+
+    let code = format!(
+        "{}\n{}",
+        format!("#define NUM_CPU {}", cpus),
+        include_str!("memory.c").to_string()
+    );
+
+    let mut bpf = BPF::new(&code)?;
+    PerfEventArray::new()
+        .table("loads_perf")
+        .event(Event::Raw {
+            event_code: 0x0E,
+            umask: 0x0F,
+            counter_mask: 0x00,
+            invert: false,
+            any_thread: false,
+            edge_detect: false,
+        })
+        .attach(&mut bpf)?;
+
+    println!("Running for {} seconds", duration);
+
+    let mut elapsed = 0;
+    while runnable.load(Ordering::SeqCst) {
+        thread::sleep(time::Duration::new(1, 0));
+
+        if elapsed == duration {
+            break;
+        }
+        elapsed += 1;
+    }
+
+    // Count misses
+    let mut loads = bpf.table("loads")?;
+    let loads_map = to_map(&mut loads);
+
+    let mut total_loads = 0;
+
+    for i in 0..cpus {
+        let loads = loads_map.get(&i).unwrap_or(&0);
+
+        total_loads += *loads;
+    }
+
+    println!("{:<-12}", "TOTAL_LOADS");
+    println!("{:<-12}", total_loads,);
+
+    Ok(())
+}
+
+fn to_map(table: &mut bcc::table::Table) -> HashMap<u32, u64> {
+    let mut map = HashMap::new();
+
+    for entry in table.iter() {
+        let key = parse_u32(entry.key);
+        let value = parse_u64(entry.value);
+
+        map.insert(key, value);
+    }
+
+    map
+}
+
+fn parse_u32(x: Vec<u8>) -> u32 {
+    let mut v = [0_u8; 4];
+    for (i, byte) in v.iter_mut().enumerate() {
+        *byte = *x.get(i).unwrap_or(&0);
+    }
+
+    u32::from_ne_bytes(v)
+}
+
+fn parse_u64(x: Vec<u8>) -> u64 {
+    let mut v = [0_u8; 8];
+    for (i, byte) in v.iter_mut().enumerate() {
+        *byte = *x.get(i).unwrap_or(&0);
+    }
+
+    u64::from_ne_bytes(v)
+}
+
+fn main() {
+    let runnable = Arc::new(AtomicBool::new(true));
+    let r = runnable.clone();
+    ctrlc::set_handler(move || {
+        r.store(false, Ordering::SeqCst);
+    })
+    .expect("Failed to set handler for SIGINT / SIGTERM");
+
+    if let Err(x) = do_main(runnable) {
+        eprintln!("Error: {}", x);
+        std::process::exit(1);
+    }
+}

--- a/src/perf_event/events.rs
+++ b/src/perf_event/events.rs
@@ -7,6 +7,14 @@ pub enum Event {
     Hardware(HardwareEvent),
     Software(SoftwareEvent),
     HardwareCache(CacheId, CacheOp, CacheResult),
+    Raw {
+        event_code: u8,
+        umask: u8,
+        counter_mask: u8,
+        invert: bool,
+        any_thread: bool,
+        edge_detect: bool,
+    },
 }
 
 #[allow(dead_code)]
@@ -93,6 +101,7 @@ impl Event {
             Event::Hardware(_) => EventType::Hardware,
             Event::Software(_) => EventType::Software,
             Event::HardwareCache(_, _, _) => EventType::HardwareCache,
+            Event::Raw { .. } => EventType::Raw,
         }) as u32
     }
 
@@ -102,6 +111,21 @@ impl Event {
             Event::Software(sw_event) => sw_event as u32,
             Event::HardwareCache(id, op, result) => {
                 ((result as u32) << 16) | ((op as u32) << 8) | (id as u32)
+            }
+            Event::Raw {
+                event_code,
+                umask,
+                counter_mask,
+                invert,
+                any_thread,
+                edge_detect,
+            } => {
+                (event_code as u32)
+                    | ((umask as u32) << 8)
+                    | ((counter_mask as u32) << 24)
+                    | ((invert as u32) << 23)
+                    | ((any_thread as u32) << 21)
+                    | ((edge_detect as u32) << 18)
             }
         }
     }


### PR DESCRIPTION
Adds a Event::Raw variant that captures the fields necessary for
creating the event configuration. This allows us to use Rust + BPF
to instrument architecture specific events.
