### PR TITLE
remove regex dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ edition = '2018'
 bcc-sys = "0.18.0"
 byteorder = "1.3.4"
 libc = "0.2.80"
-regex = "1.4.2"
 thiserror = "1.0.22"
 bitflags = "1.2.1"
 


### PR DESCRIPTION
* what problem are you trying to solve? (or if there's no problem, what's the motivation for this
  change?)

After removing this dependency it almost compiles twice as fast on my machine.

* what changes does this pull request make?

Reimplement regex with string methods

* are there any non-obvious implications of these changes? (does it break compatibility with previous
  versions, etc)

No
