### PR TITLE
Add support for attaching a BPF program to a socket

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ byteorder = "1.4.3"
 libc = "0.2.108"
 thiserror = "1.0.30"
 bitflags = "1.3.2"
+socket2 = "0.4.4"
 
 [dev-dependencies]
 clap = "2.33.3"

--- a/build/ci.sh
+++ b/build/ci.sh
@@ -14,6 +14,8 @@ function test {
     sudo $runner target/release/examples/opensnoop --duration 5
     echo "contextswitch"
     sudo $runner target/release/examples/contextswitch --duration 5
+    echo "port_filter"
+    sudo $runner target/release/examples/port_filter --duration 5
 }
 
 ## Update apt

--- a/examples/port_filter.c
+++ b/examples/port_filter.c
@@ -1,0 +1,59 @@
+#include <uapi/linux/ptrace.h>
+#include <net/sock.h>
+#include <bcc/proto.h>
+
+// This code is inspired by: https://github.com/iovisor/bcc/blob/master/examples/networking/http_filter/http-parse-simple.c
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+
+#define IP_TCP 	6
+
+#define DST_PORT {dst_port}
+
+
+int port_filter(struct __sk_buffer *skb) {
+	u8 *cursor = 0;
+
+	struct ethernet_t *ethernet = cursor_advance(cursor, sizeof(*ethernet));
+	// filter IP packets (ethernet type = 0x0800)
+	if (!(ethernet->type == 0x0800)) {
+		goto DROP;
+	}
+
+    struct ip_t *ip = cursor_advance(cursor, sizeof(*ip));
+	// filter TCP packets (ip next protocol = 0x06)
+	if (ip->nextp != IP_TCP) {
+		goto DROP;
+	}
+
+    u32  tcp_header_length = 0;
+    u32  ip_header_length = 0;
+    u32  payload_offset = 0;
+    u32  payload_length = 0;
+
+    // calculate ip header length
+    // value to multiply * 4
+    // e.g. ip->hlen = 5 ; IP Header Length = 5 x 4 byte = 20 byte
+    ip_header_length = ip->hlen << 2;    //SHL 2 -> *4 multiply
+
+    // check ip header length against minimum
+    if (ip_header_length < sizeof(*ip)) {
+            goto DROP;
+    }
+
+    // shift cursor forward for dynamic ip header size
+    void *_ = cursor_advance(cursor, (ip_header_length-sizeof(*ip)));
+
+    struct tcp_t *tcp = cursor_advance(cursor, sizeof(*tcp));
+
+    if(tcp->dst_port == DST_PORT) {
+        goto END;
+    } 
+
+DROP:
+    return 0;
+
+END:
+    // indicates that the packet can be passed to userspace
+    return -1;
+}

--- a/examples/port_filter.rs
+++ b/examples/port_filter.rs
@@ -1,0 +1,86 @@
+use bcc::SocketBuilder;
+use bcc::BPF;
+use clap::{App, Arg};
+use std::{thread, time};
+use std::io::Read;
+
+const DEFAULT_DURATION: u64 = 120; // Seconds
+
+pub fn recv_loop(mut socket_wrapper: bcc::SocketWrapper) {
+    loop {
+        let mut buf: [u8; 2048] = [0; 2048];
+        match socket_wrapper.socket.read(&mut buf) {
+            Ok(bytes) => println!("read {} bytes on interface {}", bytes, &socket_wrapper.iface),
+            Err(err) => panic!("error whild reading from socket: {}", err)
+        }
+    }
+}
+
+fn main() {
+    let matches = App::new("port_filter")
+        .arg(
+            Arg::with_name("ifaces")
+                .long("ifaces")
+                .short("i")
+                .help("interface to listen to")
+                .use_delimiter(true)
+                .default_value("eth0"),
+        )
+        .arg(
+            Arg::with_name("duration")
+                .long("duration")
+                .value_name("Seconds")
+                .help("The total duration to run this tool")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("port")
+                .long("port")
+                .short("p")
+                .help("The port to filter")
+                .takes_value(true)
+                .default_value("8080")
+        )
+        .get_matches();
+
+    let ifaces = matches
+        .values_of("ifaces")
+        .unwrap()
+        .map(String::from)
+        .collect::<Vec<String>>();
+
+    let duration: u64 = matches
+        .value_of("duration")
+        .map(|v| v.parse().expect("Invalid duration"))
+        .unwrap_or(DEFAULT_DURATION);
+
+    let port: &str = matches.value_of("port").unwrap();
+
+    println!("Running for {} seconds", duration);
+
+    let code = include_str!("port_filter.c").replace("{dst_port}", port);
+
+    let mut bpf= BPF::new(&code).unwrap();
+
+    let sockets = SocketBuilder::new()
+        .handler("port_filter")
+        .add_interfaces(&ifaces)
+        .attach(&mut bpf)
+        .unwrap();
+
+    sockets
+        .into_iter()
+        .for_each(|socket_wrapper: bcc::SocketWrapper| {
+            thread::spawn(|| {
+                recv_loop(socket_wrapper)
+            });
+        });
+
+    println!("Attached sockets to interfaces {:?} and looking for tcp packets to port {}", &ifaces, port);
+
+    let mut elapsed = 0;
+    while elapsed < duration {
+        thread::sleep(time::Duration::new(1, 0));
+        elapsed += 1;
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,6 +6,7 @@ mod tracepoint;
 mod uprobe;
 mod usdt;
 mod xdp;
+mod socket;
 
 use bcc_sys::bccapi::*;
 
@@ -15,6 +16,7 @@ pub(crate) use self::perf_event_array::PerfEventArray;
 pub(crate) use self::raw_tracepoint::RawTracepoint;
 pub(crate) use self::tracepoint::Tracepoint;
 pub(crate) use self::uprobe::Uprobe;
+pub(crate) use self::socket::RawSocket;
 pub use self::usdt::{usdt_generate_args, USDTContext};
 pub(crate) use self::xdp::XDP;
 use crate::helpers::to_cstring;

--- a/src/core/socket/mod.rs
+++ b/src/core/socket/mod.rs
@@ -1,0 +1,41 @@
+use bcc_sys::bccapi::{bpf_attach_socket, bpf_open_raw_sock};
+
+use crate::helpers::to_cstring;
+use crate::BccError;
+
+use std::fs::File;
+use std::os::unix::prelude::AsRawFd;
+
+#[derive(Debug)]
+pub struct RawSocket;
+
+impl RawSocket {
+    pub fn attach(iface: &str, code_fd: &File) -> Result<i32, BccError> {
+        let ciface = to_cstring(iface, "iface")?;
+        let sock_fd = unsafe { bpf_open_raw_sock(ciface.as_ptr()) };
+        if sock_fd < 0 {
+            return Err(BccError::AttachSocket {
+                iface: iface.to_string(),
+                error: std::io::Error::last_os_error(),
+            });
+        }
+        
+        let res = unsafe { bpf_attach_socket(sock_fd, code_fd.as_raw_fd()) };
+        if res < 0 {
+            return Err(BccError::AttachSocket {
+                iface: iface.to_string(),
+                error: std::io::Error::last_os_error(),
+            });
+        }
+
+        // set O_NONBLOCK to false
+        // otherwise read/send will result in a "Resource temporarily unavailable" error 
+        let mut flags = unsafe { libc::fcntl(sock_fd, libc::F_GETFL) };
+        flags = flags & !libc::O_NONBLOCK;
+        unsafe {
+            libc::fcntl(sock_fd, libc::F_SETFL, flags);
+        }
+
+        Ok(sock_fd)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,8 @@ pub enum BccError {
     AttachUretprobe { name: String },
     #[error("failed to attach XDP ({name}): code {code}")]
     AttachXDP { name: String, code: i32 },
+    #[error("failed to attach socket to {iface}: {error}")]
+    AttachSocket { iface: String, error: std::io::Error },
     #[error("{cause} requires bcc >= ({min_version})")]
     BccVersionTooLow { cause: String, min_version: String },
     #[error("error compiling bpf")]
@@ -53,6 +55,8 @@ pub enum BccError {
     InvalidCpuRange { range: String },
     #[error("field '{field}' contained interior null byte; can't convert to C string")]
     InvalidCString { field: &'static str },
+    #[error("socket has invalid configuration: {message}")]
+    InvalidSocket { message: String },
     #[error("error loading bpf program ({name}): {message}")]
     Loading { name: String, message: String },
     #[error("error opening perf buffer")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ mod types;
 mod uprobe;
 pub mod utils;
 mod xdp;
+mod socket;
 
 #[macro_use]
 extern crate bitflags;
@@ -35,3 +36,4 @@ pub use tracepoint::Tracepoint;
 pub use uprobe::{Uprobe, Uretprobe};
 pub use utils::*;
 pub use xdp::{Mode as XDPMode, XDP};
+pub use socket::{SocketWrapper, SocketBuilder};

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -1,0 +1,89 @@
+use bcc_sys::bccapi::bpf_prog_type_BPF_PROG_TYPE_SOCKET_FILTER as BPF_PROG_TYPE_SOCKET_FILTER;
+use std::collections::HashSet;
+use std::iter::Iterator;
+
+use std::os::unix::io::FromRawFd;
+use socket2;
+
+use crate::core::BPF;
+use crate::error::BccError;
+
+// SocketWrapper holds the BPF raw socket and the interface the BPF program was attached to
+#[derive(Debug)]
+pub struct SocketWrapper {
+    pub iface: String,
+    // socket can be used to access the underlying raw socket
+    pub socket: socket2::Socket,
+}
+
+impl SocketWrapper {
+    // create a new Socket from an interface name and a socket file descriptor
+    pub fn new(iface: String, socket_fd: i32) -> Self {
+        let socket = unsafe {socket2::Socket::from_raw_fd(socket_fd)};
+        Self { iface, socket }
+    }
+
+}
+
+/// An object that can attach a bpf program to a socket which runs on every
+/// packet on the given interfaces
+#[derive(Debug, Default)]
+pub struct SocketBuilder {
+    handler: Option<String>,
+    ifaces: HashSet<String>,
+}
+
+impl SocketBuilder {
+    /// Create a new Socket with defaults. Further initialization is required
+    /// before attaching.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Specify the name of the probe handler within the BPF code. This is a
+    /// required item.
+    pub fn handler(mut self, handler: &str) -> Self {
+        self.handler = Some(handler.to_owned());
+        self
+    }
+
+    /// Add an interface to listen to
+    pub fn add_interface(mut self, iface: &str) -> Self {
+        self.ifaces.insert(iface.to_owned());
+        self
+    }
+
+    /// Add multiple interfaces to listen to
+    pub fn add_interfaces(mut self, ifaces: &[String]) -> Self {
+        self.ifaces.extend(ifaces.iter().cloned());
+        self
+    }
+
+    /// Attach a bpf program to the socket
+    pub fn attach(self, bpf: &mut BPF) -> Result<Vec<SocketWrapper>, BccError> {
+        if self.ifaces.len() == 0 {
+            return Err(BccError::InvalidSocket {
+                message: "interface is required".to_string(),
+            });
+        }
+
+        if self.handler.is_none() {
+            return Err(BccError::InvalidSocket {
+                message: "handler is required".to_string(),
+            })
+        }
+
+        let code_fd = bpf.load(&self.handler.unwrap(), BPF_PROG_TYPE_SOCKET_FILTER, 0, 0)?;
+        let socket_map = self
+            .ifaces
+            .iter()
+            // create a BPF socket and attach
+            .map(|iface: &String| -> Result<SocketWrapper, BccError> {
+                let socket_fd = crate::core::RawSocket::attach(iface, &code_fd)?;
+                Ok(SocketWrapper::new(iface.to_owned(), socket_fd))
+            })
+            .collect::<Result<Vec<SocketWrapper>, BccError>>();
+
+        socket_map
+    }
+}


### PR DESCRIPTION
This adds support for `attach_raw_socket`. The changes are similiar to the one from #180 but this time in a more usable manner by only exposing the underlying sockets via `socket2::Socket`.

One BPF program can be attached to multiple interfaces. For each interface a raw socket is created, which is returned to the user  so it can be used for reading/sending/etc. 

As in my other PR I also included the `port_filter` example. 