### PR TITLE
fix #192

### DIFF
--- a/build/ci.sh
+++ b/build/ci.sh
@@ -67,7 +67,7 @@ if [[ $STATIC == true ]]; then
     export CFLAGS="-fPIC"
 
     BINUTILS_VERSION="2.34.90"
-    ZLIB_VERSION="1.2.11"
+    ZLIB_VERSION="1.2.12"
     XZ_VERSION="5.2.5"
     NCURSES_VERSION="6.2"
     LIBXML2_SHA="41a34e1f4ffae2ce401600dbb5fe43f8fe402641"

--- a/examples/port_filter.rs
+++ b/examples/port_filter.rs
@@ -46,6 +46,31 @@ fn main() {
         )
         .get_matches();
 
+
+    if cfg!(any(
+        feature = "v0_4_0",
+        feature = "v0_5_0",
+        feature = "v0_6_0",
+        feature = "v0_6_1",
+        feature = "v0_7_0",
+        feature = "v0_8_0",
+        feature = "v0_9_0",
+        feature = "v0_10_0",
+        feature = "v0_11_0",
+        feature = "v0_12_0",
+        feature = "v0_13_0",
+        feature = "v0_14_0",
+        feature = "v0_15_0",
+        feature = "v0_16_0",
+        feature = "v0_17_0",
+        feature = "v0_18_0",
+        feature = "v0_19_0",
+        feature = "v0_20_0",
+    )) {
+        println!("not supported for bcc < 0.21.0");
+        std::process::exit(2);
+    }
+
     let ifaces = matches
         .values_of("ifaces")
         .unwrap()

--- a/examples/port_filter.rs
+++ b/examples/port_filter.rs
@@ -67,7 +67,7 @@ fn main() {
         feature = "v0_20_0",
     )) {
         println!("not supported for bcc < 0.21.0");
-        std::process::exit(2);
+        std::process::exit(0);
     }
 
     let ifaces = matches

--- a/examples/port_filter.rs
+++ b/examples/port_filter.rs
@@ -1,8 +1,8 @@
 use bcc::SocketBuilder;
 use bcc::BPF;
 use clap::{App, Arg};
-use std::{thread, time};
 use std::io::Read;
+use std::{thread, time};
 
 const DEFAULT_DURATION: u64 = 120; // Seconds
 
@@ -10,8 +10,11 @@ pub fn recv_loop(mut socket_wrapper: bcc::SocketWrapper) {
     loop {
         let mut buf: [u8; 2048] = [0; 2048];
         match socket_wrapper.socket.read(&mut buf) {
-            Ok(bytes) => println!("read {} bytes on interface {}", bytes, &socket_wrapper.iface),
-            Err(err) => panic!("error whild reading from socket: {}", err)
+            Ok(bytes) => println!(
+                "read {} bytes on interface {}",
+                bytes, &socket_wrapper.iface
+            ),
+            Err(err) => panic!("error whild reading from socket: {}", err),
         }
     }
 }
@@ -39,7 +42,7 @@ fn main() {
                 .short("p")
                 .help("The port to filter")
                 .takes_value(true)
-                .default_value("8080")
+                .default_value("8080"),
         )
         .get_matches();
 
@@ -60,7 +63,7 @@ fn main() {
 
     let code = include_str!("port_filter.c").replace("{dst_port}", port);
 
-    let mut bpf= BPF::new(&code).unwrap();
+    let mut bpf = BPF::new(&code).unwrap();
 
     let sockets = SocketBuilder::new()
         .handler("port_filter")
@@ -71,12 +74,13 @@ fn main() {
     sockets
         .into_iter()
         .for_each(|socket_wrapper: bcc::SocketWrapper| {
-            thread::spawn(|| {
-                recv_loop(socket_wrapper)
-            });
+            thread::spawn(|| recv_loop(socket_wrapper));
         });
 
-    println!("Attached sockets to interfaces {:?} and looking for tcp packets to port {}", &ifaces, port);
+    println!(
+        "Attached sockets to interfaces {:?} and looking for tcp packets to port {}",
+        &ifaces, port
+    );
 
     let mut elapsed = 0;
     while elapsed < duration {

--- a/examples/port_filter.rs
+++ b/examples/port_filter.rs
@@ -46,7 +46,6 @@ fn main() {
         )
         .get_matches();
 
-
     if cfg!(any(
         feature = "v0_4_0",
         feature = "v0_5_0",

--- a/examples/runqlat.c
+++ b/examples/runqlat.c
@@ -41,7 +41,7 @@ int trace_run(struct pt_regs *ctx, struct task_struct *prev)
 {
     u32 pid, tgid;
     // ivcsw: treat like an enqueue event and store timestamp
-    if (prev->state == TASK_RUNNING) {
+    if (prev->__state == TASK_RUNNING) {
         tgid = prev->tgid;
         pid = prev->pid;
         if (pid != 0) {
@@ -91,7 +91,7 @@ int raw_tp__sched_switch(struct bpf_raw_tracepoint_args *ctx)
     u32 pid, tgid;
 
     // ivcsw: treat like an enqueue event and store timestamp
-    if (prev->state == TASK_RUNNING) {
+    if (prev->__state == TASK_RUNNING) {
         tgid = prev->tgid;
         pid = prev->pid;
         if (pid != 0) {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,11 +2,11 @@ mod kprobe;
 mod perf_event;
 mod perf_event_array;
 mod raw_tracepoint;
+mod socket;
 mod tracepoint;
 mod uprobe;
 mod usdt;
 mod xdp;
-mod socket;
 
 use bcc_sys::bccapi::*;
 
@@ -14,9 +14,9 @@ pub(crate) use self::kprobe::Kprobe;
 pub(crate) use self::perf_event::PerfEvent;
 pub(crate) use self::perf_event_array::PerfEventArray;
 pub(crate) use self::raw_tracepoint::RawTracepoint;
+pub(crate) use self::socket::RawSocket;
 pub(crate) use self::tracepoint::Tracepoint;
 pub(crate) use self::uprobe::Uprobe;
-pub(crate) use self::socket::RawSocket;
 pub use self::usdt::{usdt_generate_args, USDTContext};
 pub(crate) use self::xdp::XDP;
 use crate::helpers::to_cstring;

--- a/src/core/socket/mod.rs
+++ b/src/core/socket/mod.rs
@@ -19,7 +19,7 @@ impl RawSocket {
                 error: std::io::Error::last_os_error(),
             });
         }
-        
+
         let res = unsafe { bpf_attach_socket(sock_fd, code_fd.as_raw_fd()) };
         if res < 0 {
             return Err(BccError::AttachSocket {
@@ -29,7 +29,7 @@ impl RawSocket {
         }
 
         // set O_NONBLOCK to false
-        // otherwise read/send will result in a "Resource temporarily unavailable" error 
+        // otherwise read/send will result in a "Resource temporarily unavailable" error
         let mut flags = unsafe { libc::fcntl(sock_fd, libc::F_GETFL) };
         flags = flags & !libc::O_NONBLOCK;
         unsafe {

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,10 @@ pub enum BccError {
     #[error("failed to attach XDP ({name}): code {code}")]
     AttachXDP { name: String, code: i32 },
     #[error("failed to attach socket to {iface}: {error}")]
-    AttachSocket { iface: String, error: std::io::Error },
+    AttachSocket {
+        iface: String,
+        error: std::io::Error,
+    },
     #[error("{cause} requires bcc >= ({min_version})")]
     BccVersionTooLow { cause: String, min_version: String },
     #[error("error compiling bpf")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod kprobe;
 pub mod perf_event;
 mod raw_tracepoint;
 pub mod ring_buf;
+mod socket;
 pub mod symbol;
 pub mod table;
 mod tracepoint;
@@ -22,7 +23,6 @@ mod types;
 mod uprobe;
 pub mod utils;
 mod xdp;
-mod socket;
 
 #[macro_use]
 extern crate bitflags;
@@ -32,8 +32,8 @@ pub use error::BccError;
 pub use kprobe::{Kprobe, Kretprobe};
 pub use perf_event::{PerfEvent, PerfEventArray, PerfMap};
 pub use raw_tracepoint::RawTracepoint;
+pub use socket::{SocketBuilder, SocketWrapper};
 pub use tracepoint::Tracepoint;
 pub use uprobe::{Uprobe, Uretprobe};
 pub use utils::*;
 pub use xdp::{Mode as XDPMode, XDP};
-pub use socket::{SocketWrapper, SocketBuilder};

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -2,8 +2,8 @@ use bcc_sys::bccapi::bpf_prog_type_BPF_PROG_TYPE_SOCKET_FILTER as BPF_PROG_TYPE_
 use std::collections::HashSet;
 use std::iter::Iterator;
 
-use std::os::unix::io::FromRawFd;
 use socket2;
+use std::os::unix::io::FromRawFd;
 
 use crate::core::BPF;
 use crate::error::BccError;
@@ -19,10 +19,9 @@ pub struct SocketWrapper {
 impl SocketWrapper {
     // create a new Socket from an interface name and a socket file descriptor
     pub fn new(iface: String, socket_fd: i32) -> Self {
-        let socket = unsafe {socket2::Socket::from_raw_fd(socket_fd)};
+        let socket = unsafe { socket2::Socket::from_raw_fd(socket_fd) };
         Self { iface, socket }
     }
-
 }
 
 /// An object that can attach a bpf program to a socket which runs on every
@@ -70,7 +69,7 @@ impl SocketBuilder {
         if self.handler.is_none() {
             return Err(BccError::InvalidSocket {
                 message: "handler is required".to_string(),
-            })
+            });
         }
 
         let code_fd = bpf.load(&self.handler.unwrap(), BPF_PROG_TYPE_SOCKET_FILTER, 0, 0)?;

--- a/src/table.rs
+++ b/src/table.rs
@@ -14,7 +14,7 @@ pub struct Table {
 }
 
 impl Table {
-    pub fn new(id: usize, p: MutPointer) -> Table {
+    pub(crate) fn new(id: usize, p: MutPointer) -> Table {
         Table { id, p }
     }
 


### PR DESCRIPTION
Fixes #192 by making the `Table` constructor only public within the crate.
