### PR TITLE
fix #190

### DIFF
--- a/examples/tcpretrans.rs
+++ b/examples/tcpretrans.rs
@@ -104,9 +104,9 @@ fn print_ipv4_event() -> Box<dyn FnMut(&[u8]) + Send> {
             get_datetime(),
             event.pid,
             event.ip,
-            format!("{}:{}", Ipv4Addr::from(event.saddr), event.lport),
+            format!("{}:{}", Ipv4Addr::from(u32::from_be(event.saddr)), event.lport),
             event.type_,
-            format!("{}:{}", Ipv4Addr::from(event.daddr), event.dport),
+            format!("{}:{}", Ipv4Addr::from(u32::from_be(event.daddr)), event.dport),
             event.state,
         );
     })
@@ -120,9 +120,9 @@ fn print_ipv6_event() -> Box<dyn FnMut(&[u8]) + Send> {
             get_datetime(),
             event.pid,
             event.ip,
-            format!("{}:{}", Ipv6Addr::from(event.saddr), event.lport),
+            format!("{}:{}", Ipv6Addr::from(u128::from_be(event.saddr)), event.lport),
             event.type_,
-            format!("{}:{}", Ipv6Addr::from(event.daddr), event.dport),
+            format!("{}:{}", Ipv6Addr::from(u128::from_be(event.daddr)), event.dport),
             event.state,
         );
     })


### PR DESCRIPTION
Fixes #190 by using from_be to convert the network byte order to the host byte order

Signed-off-by: Jiawei Zhao <phoenix500526@163.com>

briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this
  change?)
This PR aims to fix issue #190(IP reads in reverse order in some examples)

* what changes does this pull request make?
It uses from_be to convert from network byte order to host byte order. Without this conversion, it will parse IP address in a wrong way, like parsing 192.168.15.15 into 15.15.168.192.

* are there any non-obvious implications of these changes? (does it break compatibility with previous
  versions, etc)
There are no non-obvious implications of these changes in that I only modify the example/tcpretrans.rs file. It won't impact other modules.
